### PR TITLE
Refactor use of type state

### DIFF
--- a/src/hl.rs
+++ b/src/hl.rs
@@ -872,17 +872,21 @@ impl<SPI, CS> fmt::Debug for Error<SPI, CS>
 
 
 /// Indicates that the `DW1000` instance is not initialized yet
+#[derive(Debug)]
 pub struct Uninitialized;
 
 /// Indicates that the `DW1000` instance is ready to be used
+#[derive(Debug)]
 pub struct Ready;
 
 /// Indicates that the `DW1000` instance is currently sending
+#[derive(Debug)]
 pub struct Sending {
     finished: bool,
 }
 
 /// Indicates that the `DW1000` instance is currently receiving
+#[derive(Debug)]
 pub struct Receiving {
     finished: bool,
 }

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -537,7 +537,7 @@ impl<SPI, CS, State> DW1000<SPI, CS, State>
     /// Force the DW1000 into IDLE mode
     ///
     /// Any ongoing RX/TX operations will be aborted.
-    pub fn force_idle(&mut self)
+    fn force_idle(&mut self)
         -> Result<(), Error<SPI, CS>>
     {
         self.ll.sys_ctrl().write(|w| w.trxoff(0b1))?;

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -362,6 +362,40 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
         })
     }
 
+    /// Enables transmit interrupts for the events that `wait` checks
+    ///
+    /// Overwrites any interrupt flags that were previously set.
+    pub fn enable_tx_interrupts(&mut self)
+        -> Result<(), Error<SPI, CS>>
+    {
+        self.ll.sys_mask().write(|w| w.mtxfrs(0b1))?;
+        Ok(())
+    }
+
+    /// Enables receive interrupts for the events that `wait` checks
+    ///
+    /// Overwrites any interrupt flags that were previously set.
+    pub fn enable_rx_interrupts(&mut self)
+        -> Result<(), Error<SPI, CS>>
+    {
+        self.ll()
+            .sys_mask()
+            .write(|w|
+                w
+                    .mrxdfr(0b1)
+                    .mrxfce(0b1)
+                    .mrxphe(0b1)
+                    .mrxrfsl(0b1)
+                    .mrxrfto(0b1)
+                    .mrxovrr(0b1)
+                    .mrxpto(0b1)
+                    .mrxsfdto(0b1)
+                    .mldedone(0b1)
+            )?;
+
+        Ok(())
+    }
+
     /// Clear all interrupt flags
     pub fn clear_interrupts(&mut self)
         -> Result<(), Error<SPI, CS>>
@@ -476,16 +510,6 @@ impl<SPI, CS> DW1000<SPI, CS, Sending>
                     .txfrs(0b1) // Transmit Frame Sent
             )?;
 
-        Ok(())
-    }
-
-    /// Enables interrupts for the events that `wait` checks
-    ///
-    /// Overwrites any interrupt flags that were previously set.
-    pub fn enable_interrupts(&mut self)
-        -> Result<(), Error<SPI, CS>>
-    {
-        self.ll.sys_mask().write(|w| w.mtxfrs(0b1))?;
         Ok(())
     }
 }
@@ -649,30 +673,6 @@ impl<SPI, CS> DW1000<SPI, CS, Receiving>
             seq:   self.seq,
             state: Ready,
         })
-    }
-
-    /// Enables interrupts for the events that `wait` checks
-    ///
-    /// Overwrites any interrupt flags that were previously set.
-    pub fn enable_interrupts(&mut self)
-        -> Result<(), Error<SPI, CS>>
-    {
-        self.ll()
-            .sys_mask()
-            .write(|w|
-                w
-                    .mrxdfr(0b1)
-                    .mrxfce(0b1)
-                    .mrxphe(0b1)
-                    .mrxrfsl(0b1)
-                    .mrxrfto(0b1)
-                    .mrxovrr(0b1)
-                    .mrxpto(0b1)
-                    .mrxsfdto(0b1)
-                    .mldedone(0b1)
-            )?;
-
-        Ok(())
     }
 }
 

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -161,18 +161,6 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
         Ok(())
     }
 
-    /// Returns the TX antenna delay
-    pub fn get_tx_antenna_delay(&mut self)
-        -> Result<Duration, Error<SPI, CS>>
-    {
-        let tx_antenna_delay = self.ll.tx_antd().read()?.value();
-
-        // Since `tx_antenna_delay` is `u16`, the following will never panic.
-        let tx_antenna_delay = Duration::new(tx_antenna_delay.into()).unwrap();
-
-        Ok(tx_antenna_delay)
-    }
-
     /// Sets the network id and address used for sending and receiving
     pub fn set_address(&mut self, pan_id: mac::PanId, addr: mac::ShortAddress)
         -> Result<(), Error<SPI, CS>>
@@ -186,27 +174,6 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
             )?;
 
         Ok(())
-    }
-
-    /// Returns the network id and address used for sending and receiving
-    pub fn get_address(&mut self)
-        -> Result<mac::Address, Error<SPI, CS>>
-    {
-        let panadr = self.ll.panadr().read()?;
-
-        Ok(mac::Address::Short(
-            mac::PanId(panadr.pan_id()),
-            mac::ShortAddress(panadr.short_addr()),
-        ))
-    }
-
-    /// Returns the current system time
-    pub fn sys_time(&mut self) -> Result<Instant, Error<SPI, CS>> {
-        let sys_time = self.ll.sys_time().read()?.value();
-
-        // Since hardware timestamps fit within 40 bits, the following should
-        // never panic.
-        Ok(Instant::new(sys_time).unwrap())
     }
 
     /// Send an IEEE 802.15.4 MAC frame
@@ -524,6 +491,39 @@ impl<SPI, CS, State> DW1000<SPI, CS, State>
         SPI: spi::Transfer<u8> + spi::Write<u8>,
         CS:  OutputPin,
 {
+    /// Returns the TX antenna delay
+    pub fn get_tx_antenna_delay(&mut self)
+        -> Result<Duration, Error<SPI, CS>>
+    {
+        let tx_antenna_delay = self.ll.tx_antd().read()?.value();
+
+        // Since `tx_antenna_delay` is `u16`, the following will never panic.
+        let tx_antenna_delay = Duration::new(tx_antenna_delay.into()).unwrap();
+
+        Ok(tx_antenna_delay)
+    }
+
+    /// Returns the network id and address used for sending and receiving
+    pub fn get_address(&mut self)
+        -> Result<mac::Address, Error<SPI, CS>>
+    {
+        let panadr = self.ll.panadr().read()?;
+
+        Ok(mac::Address::Short(
+            mac::PanId(panadr.pan_id()),
+            mac::ShortAddress(panadr.short_addr()),
+        ))
+    }
+
+    /// Returns the current system time
+    pub fn sys_time(&mut self) -> Result<Instant, Error<SPI, CS>> {
+        let sys_time = self.ll.sys_time().read()?.value();
+
+        // Since hardware timestamps fit within 40 bits, the following should
+        // never panic.
+        Ok(Instant::new(sys_time).unwrap())
+    }
+
     /// Provides direct access to the register-level API
     ///
     /// Be aware that by using the register-level API, you can invalidate

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -34,9 +34,9 @@ use crate::{
 
 /// Entry point to the DW1000 driver API
 pub struct DW1000<SPI, CS, State> {
-    ll:     ll::DW1000<SPI, CS>,
-    seq:    Wrapping<u8>,
-    _state: State,
+    ll:    ll::DW1000<SPI, CS>,
+    seq:   Wrapping<u8>,
+    state: State,
 }
 
 impl<SPI, CS> DW1000<SPI, CS, Uninitialized>
@@ -55,9 +55,9 @@ impl<SPI, CS> DW1000<SPI, CS, Uninitialized>
         -> Self
     {
         DW1000 {
-            ll:     ll::DW1000::new(spi, chip_select),
-            seq:    Wrapping(0),
-            _state: Uninitialized,
+            ll:    ll::DW1000::new(spi, chip_select),
+            seq:   Wrapping(0),
+            state: Uninitialized,
         }
     }
 
@@ -135,9 +135,9 @@ impl<SPI, CS> DW1000<SPI, CS, Uninitialized>
         }
 
         Ok(DW1000 {
-            ll:     self.ll,
-            seq:    self.seq,
-            _state: Ready,
+            ll:    self.ll,
+            seq:   self.seq,
+            state: Ready,
         })
     }
 }
@@ -298,9 +298,9 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
             )?;
 
         Ok(DW1000 {
-            ll:     self.ll,
-            seq:    self.seq,
-            _state: Sending { finished: false },
+            ll:    self.ll,
+            seq:   self.seq,
+            state: Sending { finished: false },
         })
     }
 
@@ -462,7 +462,7 @@ impl<SPI, CS> DW1000<SPI, CS, Sending>
         // Frame sent
         self.reset_flags()
             .map_err(|error| nb::Error::Other(error))?;
-        self._state.finished = true;
+        self.state.finished = true;
 
         Ok(())
     }
@@ -474,7 +474,7 @@ impl<SPI, CS> DW1000<SPI, CS, Sending>
     pub fn finish_sending(mut self)
         -> Result<DW1000<SPI, CS, Ready>, (Self, Error<SPI, CS>)>
     {
-        if !self._state.finished {
+        if !self.state.finished {
             // Can't use `map_err` and `?` here, as the compiler will complain
             // about `self` moving into the closure.
             match self.force_idle() {
@@ -488,9 +488,9 @@ impl<SPI, CS> DW1000<SPI, CS, Sending>
         }
 
         Ok(DW1000 {
-            ll:     self.ll,
-            seq:    self.seq,
-            _state: Ready,
+            ll:    self.ll,
+            seq:   self.seq,
+            state: Ready,
         })
     }
 

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -737,6 +737,20 @@ impl<SPI, CS, State> DW1000<SPI, CS, State>
     }
 }
 
+// Can't be derived without putting requirements on `SPI` and `CS`.
+impl<SPI, CS, State> fmt::Debug for DW1000<SPI, CS, State>
+    where
+        State: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "DW1000 {{ state: ")?;
+        self.state.fmt(f)?;
+        write!(f, ", .. }}")?;
+
+        Ok(())
+    }
+}
+
 
 /// An error that can occur when sending or receiving data
 pub enum Error<SPI, CS>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub use crate::hl::{
     Error,
     Message,
     Ready,
+    Receiving,
     Sending,
     Uninitialized,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,6 @@ pub use crate::hl::{
     Error,
     Message,
     Ready,
-    TxFuture,
+    Sending,
     Uninitialized,
 };

--- a/src/ranging.rs
+++ b/src/ranging.rs
@@ -63,7 +63,7 @@ use crate::{
     DW1000,
     Error,
     Ready,
-    TxFuture,
+    Sending,
 };
 
 
@@ -173,8 +173,8 @@ impl<T> TxMessage<T> where T: Message {
     /// Serializes the message payload and uses [`DW1000::send`] internally to
     /// send it. Returns a [`TxFuture`] to represent the current state of the
     /// send operation, if no error occurs.
-    pub fn send<'r, SPI, CS>(&self, dw1000: &'r mut DW1000<SPI, CS, Ready>)
-        -> Result<TxFuture<'r, SPI, CS>, Error<SPI, CS>>
+    pub fn send<'r, SPI, CS>(&self, dw1000: DW1000<SPI, CS, Ready>)
+        -> Result<DW1000<SPI, CS, Sending>, Error<SPI, CS>>
         where
             SPI: spi::Transfer<u8> + spi::Write<u8>,
             CS:  OutputPin,


### PR DESCRIPTION
The previous approach, using borrowing, didn't work in scenarios where `DW1000` was part of a struct. The futures would have to be stored alongside `DW1000` in such a scenario, which didn't work, as it would have made such a struct self-referential. This has been reported in #89.

This pull request addresses this problem, by removing `TxFuture` and `RxFuture`, and replacing them with additional `Sending` and `Receiving` type states on `DW1000`. Instead of returning a future which borrows `DW1000` for the duration of a send/receive operation, the `DW1000<Ready>` is moved, and replaced by a `DW1000<Sending>`/`DW1000<Receiving>`.

If stored in a struct field, `DW1000` can, depending on the use case, either be wrapped in an `enum`, or the type state can be propagated to the struct.

I've ported the examples in the `dwm1001` crate to this new API: https://github.com/braun-embedded/rust-dwm1001/pull/97

cc @jamesmunns 