### PR TITLE
lis2dh driver integration

### DIFF
--- a/dwm1001/.vscode/launch.json
+++ b/dwm1001/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Cortex Debug",
+            "cwd": "${workspaceRoot}",
+            "executable": "./target/thumbv7em-none-eabihf/release/examples/lis2dh12",
+            "request": "launch",
+            "type": "cortex-debug",
+            "servertype": "openocd",
+            "device": "nrf52832",
+            "configFiles": [
+                "vscode_openocd.cfg"
+            ]
+        }
+    ]
+}

--- a/dwm1001/.vscode/tasks.json
+++ b/dwm1001/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "cargo build --release --example lis2dh12 --features=\"dev rt semihosting\"",
+            "command": "cargo build --release --example lis2dh12 --features=\"dev rt semihosting\"",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$rustc"
+        }
+    ]
+}

--- a/dwm1001/Cargo.toml
+++ b/dwm1001/Cargo.toml
@@ -13,6 +13,10 @@ categories    = ["embedded", "hardware-support", "no-std"]
 keywords      = ["decawave", "dw1000", "bsc", "radio", "uwb"]
 
 
+[package.metadata.docs.rs]
+all-features = true
+
+
 [badges]
 travis-ci = { repository = "braun-embedded/rust-dw1000" }
 
@@ -22,6 +26,7 @@ cortex-m-rt             = { version = "0.6.3", optional = true }
 cortex-m-semihosting    = "0.3.0"
 embedded-hal            = "0.2.1"
 embedded-timeout-macros = "0.2.0"
+lis2dh12                = "0.2.0"
 
 [dependencies.dw1000]
 version = "0.3.0"
@@ -122,7 +127,4 @@ incremental   = false
 codegen-units = 1
 lto           = true
 opt-level     = 3
-
-
-[package.metadata.docs.rs]
-all-features = true
+debug         = true

--- a/dwm1001/examples/lis2dh12.rs
+++ b/dwm1001/examples/lis2dh12.rs
@@ -1,11 +1,9 @@
 //! Accesses the LIS2DH12 3-axis accelerometer
 //!
-//! To build:
-//! cargo build --example lis2dh12 --features "dev rt semihosting" --release
-//!
-//! To debug:
-//! openocd -f openocd_jlink.cfg
-//! arm-none-eabi-gdb target/thumbv7em-none-eabihf/release/examples/lis2dh12 -x debug.gdb
+//! The example use the lis2dh2 driver
+//! [lis2dh12](https://crates.io/crates/lis2dh12)
+//! The driver implements the `Accelerometer` triat
+//! [Accelerometer](https://crates.io/crates/accelerometer)
 
 #![no_main]
 #![no_std]

--- a/dwm1001/examples/lis2dh12.rs
+++ b/dwm1001/examples/lis2dh12.rs
@@ -1,43 +1,77 @@
 //! Accesses the LIS2DH12 3-axis accelerometer
+//!
+//! To build:
+//! cargo build --example lis2dh12 --features "dev rt semihosting" --release
+//!
+//! To debug:
+//! openocd -f openocd_jlink.cfg
+//! arm-none-eabi-gdb target/thumbv7em-none-eabihf/release/examples/lis2dh12 -x debug.gdb
 
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 
-use dwm1001::{
-    debug,
-    DWM1001,
-    print,
-};
+use dwm1001::{debug, print, DWM1001};
 
+use lis2dh12::{self, Accelerometer};
 
 #[entry]
 fn main() -> ! {
     debug::init();
 
-    let mut dwm1001 = DWM1001::take().unwrap();
+    print!("start\n");
+
+    let dwm1001 = DWM1001::take().unwrap();
 
     // SDO/SA0 is connected to the supply voltage, so the least significant bit
     // is 1. See datasheet, section 6.1.1.
-    let address = 0b0011001;
 
-    let mut write_buf = [0u8; 1];
-    let mut read_buf  = [0u8; 1];
+    let address = lis2dh12::SlaveAddr::Alternative(true);
 
-    // Read WHOAMI register (address 0x0F)
-    write_buf[0] = 0x0F;
-    dwm1001.LIS2DH12.write(address, &write_buf)
-        .expect("Failed to write to I2C");
-    dwm1001.LIS2DH12.read(address, &mut read_buf)
-        .expect("Failed to read from I2C");
-    assert_eq!(read_buf[0], 0b00110011);
+    let mut lis2dh12 =
+        lis2dh12::Lis2dh12::new(dwm1001.LIS2DH12, address).expect("lis2dh12 new failed");
 
-    print!("WHOAMI: {:08b}\n", read_buf[0]);
+    print!(
+        "WHOAMI: {:08b}\n",
+        lis2dh12
+            .get_device_id()
+            .expect("lis2dh12 get_device_id failed")
+    );
 
-    loop {}
+    lis2dh12
+        .set_mode(lis2dh12::Mode::HighResolution)
+        .expect("lis2dh12 set_mode failed");
+
+    lis2dh12
+        .set_odr(lis2dh12::Odr::Hz1)
+        .expect("lis2dh12 set_odr failed");
+
+    lis2dh12
+        .enable_axis((true, true, true))
+        .expect("lis2dh12 enable_axis failed");
+
+    lis2dh12
+        .enable_temp(true)
+        .expect("lis2dh2 enable_temp failed");
+
+    print!(
+        "TEMP: {:?}\n",
+        lis2dh12.get_temp_out().expect("lis2dh2 get_temp failed")
+    );
+
+    print!(
+        "TEMP_STATUS: {:?}\n",
+        lis2dh12
+            .get_temp_status()
+            .expect("lis2dh2 get_temp_status failed")
+    );
+
+    print!("STATUS: {:?}\n", lis2dh12.get_status());
+
+    loop {
+        print!("ACC: {:?}\n", lis2dh12.acceleration());
+    }
 }

--- a/dwm1001/src/lib.rs
+++ b/dwm1001/src/lib.rs
@@ -239,8 +239,11 @@ pub struct DWM1001 {
 
     /// LIS2DH12 3-axis accelerometer
     ///
-    /// So far no Rust driver exists for the LIS2DH12, so this provides direct
-    /// access to the I2C bus it's connected to.
+    /// LIS2DH12 can be used either bare or together with the
+    /// [lis2dh12](https://crates.io/crates/lis2dh12) driver.
+    ///
+    /// The `lis2dh12` driver implements the
+    /// [Accelerometer](https://crates.io/crates/accelerometer) trait
     pub LIS2DH12: Twim<nrf52::TWIM1>,
 
     /// nRF52 nRF52 core peripheral: Cache and branch predictor maintenance

--- a/dwm1001/vscode_openocd.cfg
+++ b/dwm1001/vscode_openocd.cfg
@@ -1,0 +1,24 @@
+source [find interface/jlink.cfg]
+transport select swd
+source [find target/nrf52.cfg]
+
+# Configure a flash bank
+#
+# I'm not sure what exactly that does, or why it's required, but flashing
+# doesn't work without it, so here we go.
+#
+# That "nrf51" bit in there looks wrong, but it isn't. It's the name of the
+# flash driver, and for some reason, the nRF52832 is covered by the nrf51
+# driver. As far as I can tell, there isn't even an nrf52 driver.
+#
+# As of 2018-08-13, the documentation I found on openocd.org[1] states that the
+# driver's name should be "nrf5", which makes more sense. That seems to apply to
+# the in-development version, however, not the currently released one (0.10.0).
+#
+# [1] http://openocd.org/doc/html/Flash-Commands.html#index-nrf5
+# You may need to uncomment the following line if using an older `openocd`
+# flash bank $_CHIPNAME.flash nrf51 0x00000000 0 0 0 $_TARGETNAME
+
+init
+arm semihosting enable
+reset


### PR DESCRIPTION
The `lis2dh12` example now use the `lis2dh12` driver (implementing the `Accelerometer` trait).