### PR TITLE
Require embedded-hal 0.2.3

### DIFF
--- a/dw1000/Cargo.toml
+++ b/dw1000/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "braun-embedded/rust-dw1000" }
 
 
 [dependencies]
-embedded-hal = "0.2.2"
+embedded-hal = "0.2.3"
 ieee802154   = "0.3.0"
 nb           = "0.1.1"
 


### PR DESCRIPTION
This version introduced the `digital::v2` module. `dw1000` doesn't build on older HAL versions.