### PR TITLE
Radio configuration and LEDs

### DIFF
--- a/dw1000/src/configs.rs
+++ b/dw1000/src/configs.rs
@@ -1,0 +1,280 @@
+//! Configuration structs for sending and receiving
+//!
+//! This module houses the datastructures that control how frames are transmitted and received.
+//! The configs are passed to the send and receive functions.
+
+use crate::time::Duration;
+
+/// Transmit configuration
+pub struct TxConfig {
+    /// Sets the bitrate of the transmission
+    pub bitrate: BitRate,
+    /// Sets the ranging bit in the transmitted frame.
+    /// This has no effect on the capabilities of the DW1000
+    pub ranging_enable: bool,
+    /// Sets the PRF value of the transmission
+    pub pulse_repetition_frequency: PulseRepetitionFrequency,
+    /// The length of the preamble
+    pub preamble_length: PreambleLength,
+    /// The channel that the DW1000 will transmit at.
+    pub channel: UwbChannel,
+    /// The SFD sequence that is used to transmit a frame.
+    pub sfd_sequence: SfdSequence,
+}
+
+impl Default for TxConfig {
+    fn default() -> Self {
+        TxConfig {
+            bitrate: Default::default(),
+            ranging_enable: false,
+            pulse_repetition_frequency: Default::default(),
+            preamble_length: Default::default(),
+            channel: Default::default(),
+            sfd_sequence: Default::default(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+/// The bitrate at which a message is transmitted
+pub enum BitRate {
+    /// 110 kilobits per second.
+    /// This is an unofficial extension from decawave.
+    Kbps110 = 0b00,
+    /// 850 kilobits per second.
+    Kbps850 = 0b01,
+    /// 6.8 megabits per second.
+    Kbps6800 = 0b10,
+}
+
+impl Default for BitRate {
+    fn default() -> Self {
+        BitRate::Kbps6800
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+/// The PRF value
+pub enum PulseRepetitionFrequency {
+    /// 16 megahertz
+    Mhz16 = 0b01,
+    /// 64 megahertz
+    Mhz64 = 0b10
+}
+
+impl Default for PulseRepetitionFrequency {
+    fn default() -> Self {
+        PulseRepetitionFrequency::Mhz16
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+/// An enum that specifies the length of the preamble.
+///
+/// Longer preambles improve the reception quality and thus range.
+/// This comes at the cost of longer transmission times and thus power consumption and bandwidth use.
+///
+/// For the bit pattern, see table 16 in the user manual. Two bits TXPSR,then two bits PE.
+pub enum PreambleLength {
+    /// 64 bits of preamble.
+    /// Only supported at Bitrate::Kbps6800.
+    Bits64   = 0b0100,
+    /// 128 bits of preamble.
+    /// Only supported at Bitrate::Kbps850 & Bitrate::Kbps6800.
+    /// Unofficial extension from decawave.
+    Bits128  = 0b0101,
+    /// 256 bits of preamble.
+    /// Only supported at Bitrate::Kbps850 & Bitrate::Kbps6800.
+    /// Unofficial extension from decawave.
+    Bits256  = 0b0110,
+    /// 512 bits of preamble.
+    /// Only supported at Bitrate::Kbps850 & Bitrate::Kbps6800.
+    /// Unofficial extension from decawave.
+    Bits512  = 0b0111,
+    /// 1024 bits of preamble.
+    /// Only supported at Bitrate::Kbps850 & Bitrate::Kbps6800.
+    Bits1024 = 0b1000,
+    /// 1536 bits of preamble.
+    /// Only supported at Bitrate::Kbps110.
+    /// Unofficial extension from decawave.
+    Bits1536 = 0b1001,
+    /// 2048 bits of preamble.
+    /// Only supported at Bitrate::Kbps110.
+    /// Unofficial extension from decawave.
+    Bits2048 = 0b1010,
+    /// 4096 bits of preamble.
+    /// Only supported at Bitrate::Kbps110.
+    Bits4096 = 0b1100,
+}
+
+impl Default for PreambleLength {
+    fn default() -> Self {
+        PreambleLength::Bits128
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+/// An enum that allows the selection between different SFD sequences
+pub enum SfdSequence {
+    /// The standard sequence defined by the IEEE standard.
+    IEEE,
+    /// A sequence defined by Decawave that is supposed to be more robust.
+    /// This is an unofficial addition.
+    Decawave,
+    /// Uses the sequence that is programmed in by the user.
+    /// This is an unofficial addition.
+    User
+}
+
+impl Default for SfdSequence {
+    fn default() -> Self {
+        SfdSequence::IEEE
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+/// Receive configuration
+pub struct RxConfig {
+    /// Enable frame filtering
+    ///
+    /// If true, only frames directly addressed to this node and broadcasts will
+    /// be received.
+    ///
+    /// Defaults to `true`.
+    pub frame_filtering: bool,
+    /// The expected preamble length.
+    /// This affects the chosen PAC size.
+    pub expected_preamble_length: PreambleLength,
+    /// The bitrate that will be used for reception
+    pub bitrate: BitRate,
+    /// The type of SFD sequence that will be scanned for
+    pub sfd_sequence: SfdSequence,
+    /// The time after which reception is aborted when a preamble isn't detected.
+    /// A value of 0 disables the timeout.
+    /// If the value is greater than the maximum time, then the maximum time will be used.
+    pub preamble_timeout: Duration,
+    /// The channel that the DW1000 will listen at.
+    pub channel: UwbChannel,
+    /// Sets the PRF value of the reception
+    pub pulse_repetition_frequency: PulseRepetitionFrequency,
+}
+
+impl Default for RxConfig {
+    fn default() -> Self {
+        Self {
+            frame_filtering: true,
+            expected_preamble_length: Default::default(),
+            bitrate: Default::default(),
+            sfd_sequence: Default::default(),
+            preamble_timeout: Duration::from_nanos(0),
+            channel: Default::default(),
+            pulse_repetition_frequency: Default::default(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+/// All the available UWB channels.
+///
+/// Note that while a channel may have more bandwidth than ~900 Mhz, the DW1000 can only send up to ~900 Mhz
+pub enum UwbChannel {
+    /// Channel 1
+    /// - Center frequency: 3494.4 Mhz
+    /// - Bandwidth: 499.2 Mhz
+    Channel1 = 1,
+    /// Channel 2
+    /// - Center frequency: 3993.6 Mhz
+    /// - Bandwidth: 499.2 Mhz
+    Channel2 = 2,
+    /// Channel 3
+    /// - Center frequency: 4492.8 Mhz
+    /// - Bandwidth: 499.2 Mhz
+    Channel3 = 3,
+    /// Channel 4
+    /// - Center frequency: 3993.6 Mhz
+    /// - Bandwidth: 1331.2 Mhz
+    Channel4 = 4,
+    /// Channel 5
+    /// - Center frequency: 6489.6 Mhz
+    /// - Bandwidth: 499.2 Mhz
+    Channel5 = 5,
+    /// Channel 7
+    /// - Center frequency: 6489.6 Mhz
+    /// - Bandwidth: 1081.6 Mhz
+    Channel7 = 7,
+}
+
+impl Default for UwbChannel {
+    fn default() -> Self {
+        UwbChannel::Channel5
+    }
+}
+
+impl UwbChannel {
+    /// Gets the recommended preamble code
+    pub fn get_recommended_preamble_code(&self, prf_value: PulseRepetitionFrequency) -> u8 {
+        // Many have overlapping possibilities, so the numbers have been chosen so that there's no overlap here
+        match (self, prf_value) {
+            (UwbChannel::Channel1, PulseRepetitionFrequency::Mhz16) => 1,
+            (UwbChannel::Channel2, PulseRepetitionFrequency::Mhz16) => 3,
+            (UwbChannel::Channel3, PulseRepetitionFrequency::Mhz16) => 5,
+            (UwbChannel::Channel4, PulseRepetitionFrequency::Mhz16) => 7,
+            (UwbChannel::Channel5, PulseRepetitionFrequency::Mhz16) => 4,
+            (UwbChannel::Channel7, PulseRepetitionFrequency::Mhz16) => 8,
+            (UwbChannel::Channel1, PulseRepetitionFrequency::Mhz64) => 9,
+            (UwbChannel::Channel2, PulseRepetitionFrequency::Mhz64) => 10,
+            (UwbChannel::Channel3, PulseRepetitionFrequency::Mhz64) => 11,
+            (UwbChannel::Channel4, PulseRepetitionFrequency::Mhz64) => 17,
+            (UwbChannel::Channel5, PulseRepetitionFrequency::Mhz64) => 12,
+            (UwbChannel::Channel7, PulseRepetitionFrequency::Mhz64) => 18,
+        }
+    }
+
+    /// Gets the recommended value for the rf_txctrl register
+    pub fn get_recommended_rf_txctrl(&self) -> u32 {
+        // Values based on Table 38 of the DW1000 User Manual
+        match self {
+            UwbChannel::Channel1 => 0x00005C40,
+            UwbChannel::Channel2 => 0x00045CA0,
+            UwbChannel::Channel3 => 0x00086CC0,
+            UwbChannel::Channel4 => 0x00045C80,
+            UwbChannel::Channel5 => 0x001E3FE0,
+            UwbChannel::Channel7 => 0x001E7DE0,
+        }
+    }
+
+    /// Gets the recommended value for the tc_pgdelay register
+    pub fn get_recommended_tc_pgdelay(&self) -> u8 {
+        // Values based on Table 40 of the DW1000 User Manual
+        match self {
+            UwbChannel::Channel1 => 0xC9,
+            UwbChannel::Channel2 => 0xC2,
+            UwbChannel::Channel3 => 0xC5,
+            UwbChannel::Channel4 => 0x95,
+            UwbChannel::Channel5 => 0xC0,
+            UwbChannel::Channel7 => 0x93,
+        }
+    }
+
+    /// Gets the recommended value for the fs_pllcfg register
+    pub fn get_recommended_fs_pllcfg(&self) -> u32 {
+        // Values based on Table 43 of the DW1000 User Manual
+        match self {
+            UwbChannel::Channel1 => 0x09000407,
+            UwbChannel::Channel2 | UwbChannel::Channel4 => 0x08400508,
+            UwbChannel::Channel3 => 0x08401009,
+            UwbChannel::Channel5 | UwbChannel::Channel7 => 0x0800041D,
+        }
+    }
+
+    /// Gets the recommended value for the fs_plltune register
+    pub fn get_recommended_fs_plltune(&self) -> u8 {
+        // Values based on Table 44 of the DW1000 User Manual
+        match self {
+            UwbChannel::Channel1 => 0x1E,
+            UwbChannel::Channel2 | UwbChannel::Channel4 => 0x26,
+            UwbChannel::Channel3 => 0x56,
+            UwbChannel::Channel5 | UwbChannel::Channel7 => 0xBE,
+        }
+    }
+}

--- a/dw1000/src/configs.rs
+++ b/dw1000/src/configs.rs
@@ -252,12 +252,22 @@ impl PreambleLength {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 /// An enum that allows the selection between different SFD sequences
+///
+/// The difference between the two Decawave sequences is that there are two ways to enable it in the chip.
+/// Decawave will only set the DWSFD bit and DecawaveAlt set the DWSFD and the [T,R]NSSFD bits.
+///
 pub enum SfdSequence {
     /// The standard sequence defined by the IEEE standard.
+    /// Most likely the best choice for 6.8 Mbps connections.
     IEEE,
     /// A sequence defined by Decawave that is supposed to be more robust.
     /// This is an unofficial addition.
+    /// Most likely the best choice for 110 Kbps connections.
     Decawave,
+    /// A sequence defined by Decawave that is supposed to be more robust.
+    /// This is an unofficial addition.
+    /// Most likely the best choice for 850 Kbps connections.
+    DecawaveAlt,
     /// Uses the sequence that is programmed in by the user.
     /// This is an unofficial addition.
     User,

--- a/dw1000/src/configs.rs
+++ b/dw1000/src/configs.rs
@@ -8,14 +8,14 @@ use embedded_hal::{blocking::spi, digital::v2::OutputPin};
 
 /// Transmit configuration
 pub struct TxConfig {
-    /// Sets the bitrate of the transmission
+    /// Sets the bitrate of the transmission.
     pub bitrate: BitRate,
     /// Sets the ranging bit in the transmitted frame.
-    /// This has no effect on the capabilities of the DW1000
+    /// This has no effect on the capabilities of the DW1000.
     pub ranging_enable: bool,
-    /// Sets the PRF value of the transmission
+    /// Sets the PRF value of the transmission.
     pub pulse_repetition_frequency: PulseRepetitionFrequency,
-    /// The length of the preamble
+    /// The length of the preamble.
     pub preamble_length: PreambleLength,
     /// The channel that the DW1000 will transmit at.
     pub channel: UwbChannel,
@@ -39,7 +39,7 @@ impl Default for TxConfig {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 /// Receive configuration
 pub struct RxConfig {
-    /// The bitrate that will be used for reception
+    /// The bitrate that will be used for reception.
     pub bitrate: BitRate,
     /// Enable frame filtering
     ///
@@ -51,11 +51,14 @@ pub struct RxConfig {
     /// Sets the PRF value of the reception
     pub pulse_repetition_frequency: PulseRepetitionFrequency,
     /// The expected preamble length.
+    ///
     /// This affects the chosen PAC size.
+    /// This should be the same as the preamble length that is used to send the messages.
+    /// It is not a filter, though, so other preamble lengths may still be received.
     pub expected_preamble_length: PreambleLength,
     /// The channel that the DW1000 will listen at.
     pub channel: UwbChannel,
-    /// The type of SFD sequence that will be scanned for
+    /// The type of SFD sequence that will be scanned for.
     pub sfd_sequence: SfdSequence,
 }
 
@@ -160,40 +163,40 @@ impl PulseRepetitionFrequency {
 ///
 /// For the bit pattern, see table 16 in the user manual. Two bits TXPSR,then two bits PE.
 pub enum PreambleLength {
-    /// 64 bits of preamble.
+    /// 64 symbols of preamble.
     /// Only supported at Bitrate::Kbps6800.
-    Bits64 = 0b0100,
-    /// 128 bits of preamble.
+    Symbols64 = 0b0100,
+    /// 128 symbols of preamble.
     /// Only supported at Bitrate::Kbps850 & Bitrate::Kbps6800.
     /// Unofficial extension from decawave.
-    Bits128 = 0b0101,
-    /// 256 bits of preamble.
+    Symbols128 = 0b0101,
+    /// 256 symbols of preamble.
     /// Only supported at Bitrate::Kbps850 & Bitrate::Kbps6800.
     /// Unofficial extension from decawave.
-    Bits256 = 0b0110,
-    /// 512 bits of preamble.
+    Symbols256 = 0b0110,
+    /// 512 symbols of preamble.
     /// Only supported at Bitrate::Kbps850 & Bitrate::Kbps6800.
     /// Unofficial extension from decawave.
-    Bits512 = 0b0111,
-    /// 1024 bits of preamble.
+    Symbols512 = 0b0111,
+    /// 1024 symbols of preamble.
     /// Only supported at Bitrate::Kbps850 & Bitrate::Kbps6800.
-    Bits1024 = 0b1000,
-    /// 1536 bits of preamble.
+    Symbols1024 = 0b1000,
+    /// 1536 symbols of preamble.
     /// Only supported at Bitrate::Kbps110.
     /// Unofficial extension from decawave.
-    Bits1536 = 0b1001,
-    /// 2048 bits of preamble.
+    Symbols1536 = 0b1001,
+    /// 2048 symbols of preamble.
     /// Only supported at Bitrate::Kbps110.
     /// Unofficial extension from decawave.
-    Bits2048 = 0b1010,
-    /// 4096 bits of preamble.
+    Symbols2048 = 0b1010,
+    /// 4096 symbols of preamble.
     /// Only supported at Bitrate::Kbps110.
-    Bits4096 = 0b1100,
+    Symbols4096 = 0b1100,
 }
 
 impl Default for PreambleLength {
     fn default() -> Self {
-        PreambleLength::Bits128
+        PreambleLength::Symbols128
     }
 }
 
@@ -202,14 +205,14 @@ impl PreambleLength {
     pub fn get_recommended_pac_size(&self) -> u8 {
         // Values are taken from Table 6 of the DW1000 User manual
         match self {
-            PreambleLength::Bits64 => 8,
-            PreambleLength::Bits128 => 8,
-            PreambleLength::Bits256 => 16,
-            PreambleLength::Bits512 => 16,
-            PreambleLength::Bits1024 => 32,
-            PreambleLength::Bits1536 => 64,
-            PreambleLength::Bits2048 => 64,
-            PreambleLength::Bits4096 => 64,
+            PreambleLength::Symbols64 => 8,
+            PreambleLength::Symbols128 => 8,
+            PreambleLength::Symbols256 => 16,
+            PreambleLength::Symbols512 => 16,
+            PreambleLength::Symbols1024 => 32,
+            PreambleLength::Symbols1536 => 64,
+            PreambleLength::Symbols2048 => 64,
+            PreambleLength::Symbols4096 => 64,
         }
     }
 
@@ -224,18 +227,18 @@ impl PreambleLength {
     {
         // Values are taken from Table 32 of the DW1000 User manual
         match (self, bitrate) {
-            (PreambleLength::Bits64, BitRate::Kbps6800) => Ok(0x0010),
-            (PreambleLength::Bits128, BitRate::Kbps6800) => Ok(0x0020),
-            (PreambleLength::Bits256, BitRate::Kbps6800) => Ok(0x0020),
-            (PreambleLength::Bits512, BitRate::Kbps6800) => Ok(0x0020),
-            (PreambleLength::Bits1024, BitRate::Kbps6800) => Ok(0x0020),
-            (PreambleLength::Bits128, BitRate::Kbps850) => Ok(0x0020),
-            (PreambleLength::Bits256, BitRate::Kbps850) => Ok(0x0020),
-            (PreambleLength::Bits512, BitRate::Kbps850) => Ok(0x0020),
-            (PreambleLength::Bits1024, BitRate::Kbps850) => Ok(0x0020),
-            (PreambleLength::Bits1536, BitRate::Kbps110) => Ok(0x0064),
-            (PreambleLength::Bits2048, BitRate::Kbps110) => Ok(0x0064),
-            (PreambleLength::Bits4096, BitRate::Kbps110) => Ok(0x0064),
+            (PreambleLength::Symbols64, BitRate::Kbps6800) => Ok(0x0010),
+            (PreambleLength::Symbols128, BitRate::Kbps6800) => Ok(0x0020),
+            (PreambleLength::Symbols256, BitRate::Kbps6800) => Ok(0x0020),
+            (PreambleLength::Symbols512, BitRate::Kbps6800) => Ok(0x0020),
+            (PreambleLength::Symbols1024, BitRate::Kbps6800) => Ok(0x0020),
+            (PreambleLength::Symbols128, BitRate::Kbps850) => Ok(0x0020),
+            (PreambleLength::Symbols256, BitRate::Kbps850) => Ok(0x0020),
+            (PreambleLength::Symbols512, BitRate::Kbps850) => Ok(0x0020),
+            (PreambleLength::Symbols1024, BitRate::Kbps850) => Ok(0x0020),
+            (PreambleLength::Symbols1536, BitRate::Kbps110) => Ok(0x0064),
+            (PreambleLength::Symbols2048, BitRate::Kbps110) => Ok(0x0064),
+            (PreambleLength::Symbols4096, BitRate::Kbps110) => Ok(0x0064),
             _ => Err(Error::InvalidConfiguration),
         }
     }
@@ -244,7 +247,7 @@ impl PreambleLength {
     pub fn get_recommended_dxr_tune4h(&self) -> u16 {
         // Values are taken from Table 34 of the DW1000 User manual
         match self {
-            PreambleLength::Bits64 => 0x0010,
+            PreambleLength::Symbols64 => 0x0010,
             _ => 0x0028,
         }
     }

--- a/dw1000/src/hl.rs
+++ b/dw1000/src/hl.rs
@@ -422,13 +422,20 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
     /// TXLED will change GPIO3
     ///
     /// blink_time is in units of 14 ms
-    pub fn configure_leds(&mut self, enable_rx_ok: bool, enable_sfd: bool, enable_rx: bool, enable_tx: bool, blink_time: u8) {
+    pub fn configure_leds(
+        &mut self,
+        enable_rx_ok: bool,
+        enable_sfd: bool,
+        enable_rx: bool,
+        enable_tx: bool,
+        blink_time: u8)
+        -> Result<(), Error<SPI, CS>> {
         // Turn on the led blinking
         self.ll.pmsc_ledc().modify(|_, w| {
            w
                .blnken((enable_rx_ok || enable_sfd || enable_rx || enable_tx) as u8)
                .blink_tim(blink_time)
-        });
+        })?;
 
         // Set the proper gpio mode
         self.ll.gpio_mode().modify(|_, w| {
@@ -437,7 +444,9 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
                 .msgp1(enable_sfd as u8)
                 .msgp2(enable_rx as u8)
                 .msgp3(enable_tx as u8)
-        });
+        })?;
+
+        Ok(())
     }
 }
 

--- a/dw1000/src/hl.rs
+++ b/dw1000/src/hl.rs
@@ -191,6 +191,11 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
     /// `delayed_time` to `Some(instant)`. If you want to send the frame as soon
     /// as possible, just pass `None` instead.
     ///
+    /// The config parameter struct allows for setting the channel, bitrate, and
+    /// more. This configuration needs to be the same as the configuration used
+    /// by the receiver, or the message may not be received.
+    /// The defaults are a sane starting point.
+    ///
     /// This method starts the transmission and returns immediately thereafter.
     /// It consumes this instance of `DW1000` and returns another instance which
     /// is in the `Sending` state, and can be used to wait for the transmission
@@ -320,7 +325,10 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
     /// and returns another instance which is in the `Receiving` state, and can
     /// be used to wait for a message.
     ///
-    /// Only frames addressed to this device will be received.
+    /// The config parameter allows for the configuration of bitrate, channel
+    /// and more. Make sure that the values used are the same as of the frames
+    /// that are transmitted. The default works with the TxConfig's default and
+    /// is a sane starting point.
     pub fn receive(mut self, config: RxConfig)
         -> Result<DW1000<SPI, CS, Receiving>, Error<SPI, CS>>
     {

--- a/dw1000/src/hl.rs
+++ b/dw1000/src/hl.rs
@@ -420,7 +420,17 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
     /// SFDLED will change GPIO1
     /// RXLED will change GPIO2
     /// TXLED will change GPIO3
-    pub fn configure_leds(&mut self, enable_rx_ok: bool, enable_sfd: bool, enable_rx: bool, enable_tx: bool) {
+    ///
+    /// blink_time is in units of 14 ms
+    pub fn configure_leds(&mut self, enable_rx_ok: bool, enable_sfd: bool, enable_rx: bool, enable_tx: bool, blink_time: u8) {
+        // Turn on the led blinking
+        self.ll.pmsc_ledc().modify(|_, w| {
+           w
+               .blnken((enable_rx_ok || enable_sfd || enable_rx || enable_tx) as u8)
+               .blink_tim(blink_time)
+        });
+
+        // Set the proper gpio mode
         self.ll.gpio_mode().modify(|_, w| {
             w
                 .msgp0(enable_rx_ok as u8)

--- a/dw1000/src/hl.rs
+++ b/dw1000/src/hl.rs
@@ -430,6 +430,11 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
         enable_tx: bool,
         blink_time: u8)
         -> Result<(), Error<SPI, CS>> {
+        // Turn on the timer that will control the blinking (The debounce clock)
+        self.ll.pmsc_ctrl0().modify(|_, w| {
+            w.gpdce((enable_rx_ok || enable_sfd || enable_rx || enable_tx) as u8)
+        });
+
         // Turn on the led blinking
         self.ll.pmsc_ledc().modify(|_, w| {
            w

--- a/dw1000/src/hl.rs
+++ b/dw1000/src/hl.rs
@@ -32,11 +32,10 @@ use crate::{
     configs::{
         TxConfig,
         RxConfig,
-        SfdSequence
+        SfdSequence,
+        BitRate,
     },
 };
-use crate::configs::BitRate;
-
 
 /// Entry point to the DW1000 driver API
 pub struct DW1000<SPI, CS, State> {

--- a/dw1000/src/hl.rs
+++ b/dw1000/src/hl.rs
@@ -412,6 +412,23 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
         self.ll.sys_mask().write(|w| w)?;
         Ok(())
     }
+
+    /// Configures the gpio pins to operate as LED output.
+    /// Note: This means that the function of the gpio pins change
+    ///
+    /// RXOKLED will change GPIO0
+    /// SFDLED will change GPIO1
+    /// RXLED will change GPIO2
+    /// TXLED will change GPIO3
+    pub fn configure_leds(&mut self, enable_rx_ok: bool, enable_sfd: bool, enable_rx: bool, enable_tx: bool) {
+        self.ll.gpio_mode().modify(|_, w| {
+            w
+                .msgp0(enable_rx_ok as u8)
+                .msgp1(enable_sfd as u8)
+                .msgp2(enable_rx as u8)
+                .msgp3(enable_tx as u8)
+        });
+    }
 }
 
 impl<SPI, CS> DW1000<SPI, CS, Sending>

--- a/dw1000/src/hl.rs
+++ b/dw1000/src/hl.rs
@@ -414,12 +414,14 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
     }
 
     /// Configures the gpio pins to operate as LED output.
-    /// Note: This means that the function of the gpio pins change
     ///
-    /// RXOKLED will change GPIO0
-    /// SFDLED will change GPIO1
-    /// RXLED will change GPIO2
-    /// TXLED will change GPIO3
+    /// - Note: This means that the function of the gpio pins change
+    /// - Note: Both the kilohertz and debounce clock will be turned on or off
+    /// ---
+    /// - RXOKLED will change GPIO0
+    /// - SFDLED will change GPIO1
+    /// - RXLED will change GPIO2
+    /// - TXLED will change GPIO3
     ///
     /// blink_time is in units of 14 ms
     pub fn configure_leds(
@@ -432,7 +434,9 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
         -> Result<(), Error<SPI, CS>> {
         // Turn on the timer that will control the blinking (The debounce clock)
         self.ll.pmsc_ctrl0().modify(|_, w| {
-            w.gpdce((enable_rx_ok || enable_sfd || enable_rx || enable_tx) as u8)
+            w
+                .gpdce((enable_rx_ok || enable_sfd || enable_rx || enable_tx) as u8)
+                .khzclken((enable_rx_ok || enable_sfd || enable_rx || enable_tx) as u8)
         });
 
         // Turn on the led blinking

--- a/dw1000/src/hl.rs
+++ b/dw1000/src/hl.rs
@@ -437,7 +437,7 @@ impl<SPI, CS> DW1000<SPI, CS, Ready>
             w
                 .gpdce((enable_rx_ok || enable_sfd || enable_rx || enable_tx) as u8)
                 .khzclken((enable_rx_ok || enable_sfd || enable_rx || enable_tx) as u8)
-        });
+        })?;
 
         // Turn on the led blinking
         self.ll.pmsc_ledc().modify(|_, w| {

--- a/dw1000/src/lib.rs
+++ b/dw1000/src/lib.rs
@@ -31,6 +31,7 @@ pub mod ll;
 pub mod hl;
 pub mod ranging;
 pub mod time;
+pub mod configs;
 
 
 #[doc(no_inline)]
@@ -42,7 +43,11 @@ pub use crate::hl::{
     Message,
     Ready,
     Receiving,
-    RxConfig,
     Sending,
     Uninitialized,
+};
+
+pub use crate::configs::{
+    TxConfig,
+    RxConfig
 };

--- a/dw1000/src/ll.rs
+++ b/dw1000/src/ll.rs
@@ -991,6 +991,11 @@ impl_register! {
         lderune,   17, 17, u8; /// LDE Run Enable
         khzclkdiv, 26, 31, u8; /// Kilohertz Clock Divisor
     }
+    0x36, 0x28, 4, RW, PMSC_LEDC(pmsc_ledc) { /// PMSC LED Control Register
+        blink_tim, 0, 7, u8; /// Blink time count value
+        blnken, 8, 8, u8; /// Blink Enable
+        blnknow, 16, 19, u8; // Manually triggers an LED blink. There is one trigger bit per LED IO
+    }
 }
 
 

--- a/dw1000/src/ll.rs
+++ b/dw1000/src/ll.rs
@@ -971,7 +971,7 @@ impl_register! {
         value, 0, 7, u8; /// Transmitter Calibration - Pulse Generator Delay
     }
     0x2B, 0x07, 4, RW, FS_PLLCFG(fs_pllcfg) { /// Frequency synth - PLL configuration
-        value, 0, 31, u32; /// /// Frequency synth - PLL configuration
+        value, 0, 31, u32; /// Frequency synth - PLL configuration
     }
     0x2B, 0x0B, 1, RW, FS_PLLTUNE(fs_plltune) { /// Frequency synth - PLL Tuning
         value, 0, 7, u8; /// Frequency synthesiser - PLL Tuning

--- a/dw1000/src/ll.rs
+++ b/dw1000/src/ll.rs
@@ -788,6 +788,134 @@ impl_register! {
         wait,    3, 10, u8; /// Wait Counter
         ostrm,  11, 11, u8; /// External Timebase Reset Mode Enable
     }
+    0x26, 0x00, 4, RW, GPIO_MODE(gpio_mode) { /// GPIO Mode Control Register
+        msgp0,  6,  7, u8; /// Mode Selection for GPIO0/RXOKLED
+        msgp1,  8,  9, u8; /// Mode Selection for GPIO1/SFDLED
+        msgp2, 10, 11, u8; /// Mode Selection for GPIO2/RXLED
+        msgp3, 12, 13, u8; /// Mode Selection for GPIO3/TXLED
+        msgp4, 14, 15, u8; /// Mode Selection for GPIO4/EXTPA
+        msgp5, 16, 17, u8; /// Mode Selection for GPIO5/EXTTXE
+        msgp6, 18, 19, u8; /// Mode Selection for GPIO6/EXTRXE
+        msgp7, 20, 21, u8; /// Mode Selection for SYNC/GPIO7
+        msgp8, 22, 23, u8; /// Mode Selection for IRQ/GPIO8
+    }
+    0x26, 0x08, 4, RW, GPIO_DIR(gpio_dir) { /// GPIO Direction Control Register
+        gdp0,  0,  0, u8; /// Direction Selection for GPIO0
+        gdp1,  1,  1, u8; /// Direction Selection for GPIO1
+        gdp2,  2,  2, u8; /// Direction Selection for GPIO2
+        gdp3,  3,  3, u8; /// Direction Selection for GPIO3
+        gdm0,  4,  4, u8; /// Mask for setting the direction of GPIO0
+        gdm1,  5,  5, u8; /// Mask for setting the direction of GPIO1
+        gdm2,  6,  6, u8; /// Mask for setting the direction of GPIO2
+        gdm3,  7,  7, u8; /// Mask for setting the direction of GPIO3
+        gdp4,  8,  8, u8; /// Direction Selection for GPIO4
+        gdp5,  9,  9, u8; /// Direction Selection for GPIO5
+        gdp6, 10, 10, u8; /// Direction Selection for GPIO6
+        gdp7, 11, 11, u8; /// Direction Selection for GPIO7
+        gdm4, 12, 12, u8; /// Mask for setting the direction of GPIO4
+        gdm5, 13, 13, u8; /// Mask for setting the direction of GPIO5
+        gdm6, 14, 14, u8; /// Mask for setting the direction of GPIO6
+        gdm7, 15, 15, u8; /// Mask for setting the direction of GPIO7
+        gdp8, 16, 16, u8; /// Direction Selection for GPIO8
+        gdm8, 20, 20, u8; /// Mask for setting the direction of GPIO8
+    }
+    0x26, 0x0C, 4, RW, GPIO_DOUT(gpio_dout) { /// GPIO Data Output register
+        gop0,  0,  0, u8; /// Output state setting for GPIO0
+        gop1,  1,  1, u8; /// Output state setting for GPIO1
+        gop2,  2,  2, u8; /// Output state setting for GPIO2
+        gop3,  3,  3, u8; /// Output state setting for GPIO3
+        gom0,  4,  4, u8; /// Mask for setting the output state of GPIO0
+        gom1,  5,  5, u8; /// Mask for setting the output state of GPIO1
+        gom2,  6,  6, u8; /// Mask for setting the output state of GPIO2
+        gom3,  7,  7, u8; /// Mask for setting the output state of GPIO3
+        gop4,  8,  8, u8; /// Output state setting for GPIO4
+        gop5,  9,  9, u8; /// Output state setting for GPIO5
+        gop6, 10, 10, u8; /// Output state setting for GPIO6
+        gop7, 11, 11, u8; /// Output state setting for GPIO7
+        gom4, 12, 12, u8; /// Mask for setting the output state of GPIO4
+        gom5, 13, 13, u8; /// Mask for setting the output state of GPIO5
+        gom6, 14, 14, u8; /// Mask for setting the output state of GPIO6
+        gom7, 15, 15, u8; /// Mask for setting the output state of GPIO7
+        gop8, 16, 16, u8; /// Output state setting for GPIO8
+        gom8, 20, 20, u8; /// Mask for setting the output state of GPIO8
+    }
+    0x26, 0x10, 4, RW, GPIO_IRQE(gpio_irqe) { /// GPIO Interrupt Enable
+        girqe0,  0,  0, u8; /// GPIO IRQ Enable for GPIO0 input
+        girqe1,  1,  1, u8; /// GPIO IRQ Enable for GPIO1 input
+        girqe2,  2,  2, u8; /// GPIO IRQ Enable for GPIO2 input
+        girqe3,  3,  3, u8; /// GPIO IRQ Enable for GPIO3 input
+        girqe4,  4,  4, u8; /// GPIO IRQ Enable for GPIO4 input
+        girqe5,  5,  5, u8; /// GPIO IRQ Enable for GPIO5 input
+        girqe6,  6,  6, u8; /// GPIO IRQ Enable for GPIO6 input
+        girqe7,  7,  7, u8; /// GPIO IRQ Enable for GPIO7 input
+        girqe8,  8,  8, u8; /// GPIO IRQ Enable for GPIO8 input
+    }
+    0x26, 0x14, 4, RW, GPIO_ISEN(gpio_isen) { /// GPIO Interrupt Sense Selection
+        gisen0,  0,  0, u8; /// GPIO IRQ sense for GPIO0 input
+        gisen1,  1,  1, u8; /// GPIO IRQ sense for GPIO1 input
+        gisen2,  2,  2, u8; /// GPIO IRQ sense for GPIO2 input
+        gisen3,  3,  3, u8; /// GPIO IRQ sense for GPIO3 input
+        gisen4,  4,  4, u8; /// GPIO IRQ sense for GPIO4 input
+        gisen5,  5,  5, u8; /// GPIO IRQ sense for GPIO5 input
+        gisen6,  6,  6, u8; /// GPIO IRQ sense for GPIO6 input
+        gisen7,  7,  7, u8; /// GPIO IRQ sense for GPIO7 input
+        gisen8,  8,  8, u8; /// GPIO IRQ sense for GPIO8 input
+    }
+    0x26, 0x18, 4, RW, GPIO_IMODE(gpio_imode) { /// GPIO Interrupt Mode (Level / Edge)
+        gimod0,  0,  0, u8; /// GPIO IRQ mode selection for GPIO0 input
+        gimod1,  1,  1, u8; /// GPIO IRQ mode selection for GPIO1 input
+        gimod2,  2,  2, u8; /// GPIO IRQ mode selection for GPIO2 input
+        gimod3,  3,  3, u8; /// GPIO IRQ mode selection for GPIO3 input
+        gimod4,  4,  4, u8; /// GPIO IRQ mode selection for GPIO4 input
+        gimod5,  5,  5, u8; /// GPIO IRQ mode selection for GPIO5 input
+        gimod6,  6,  6, u8; /// GPIO IRQ mode selection for GPIO6 input
+        gimod7,  7,  7, u8; /// GPIO IRQ mode selection for GPIO7 input
+        gimod8,  8,  8, u8; /// GPIO IRQ mode selection for GPIO8 input
+    }
+    0x26, 0x1C, 4, RW, GPIO_IBES(gpio_ibes) { /// GPIO Interrupt “Both Edge” Select
+        gibes0,  0,  0, u8; /// GPIO IRQ "Both Edges" selection for GPIO0 input
+        gibes1,  1,  1, u8; /// GPIO IRQ "Both Edges" selection for GPIO1 input
+        gibes2,  2,  2, u8; /// GPIO IRQ "Both Edges" selection for GPIO2 input
+        gibes3,  3,  3, u8; /// GPIO IRQ "Both Edges" selection for GPIO3 input
+        gibes4,  4,  4, u8; /// GPIO IRQ "Both Edges" selection for GPIO4 input
+        gibes5,  5,  5, u8; /// GPIO IRQ "Both Edges" selection for GPIO5 input
+        gibes6,  6,  6, u8; /// GPIO IRQ "Both Edges" selection for GPIO6 input
+        gibes7,  7,  7, u8; /// GPIO IRQ "Both Edges" selection for GPIO7 input
+        gibes8,  8,  8, u8; /// GPIO IRQ "Both Edges" selection for GPIO8 input
+    }
+    0x26, 0x20, 4, RW, GPIO_ICLR(gpio_iclr) { /// GPIO Interrupt Latch Clear
+        giclr0,  0,  0, u8; /// GPIO IRQ latch clear for GPIO0 input
+        giclr1,  1,  1, u8; /// GPIO IRQ latch clear for GPIO1 input
+        giclr2,  2,  2, u8; /// GPIO IRQ latch clear for GPIO2 input
+        giclr3,  3,  3, u8; /// GPIO IRQ latch clear for GPIO3 input
+        giclr4,  4,  4, u8; /// GPIO IRQ latch clear for GPIO4 input
+        giclr5,  5,  5, u8; /// GPIO IRQ latch clear for GPIO5 input
+        giclr6,  6,  6, u8; /// GPIO IRQ latch clear for GPIO6 input
+        giclr7,  7,  7, u8; /// GPIO IRQ latch clear for GPIO7 input
+        giclr8,  8,  8, u8; /// GPIO IRQ latch clear for GPIO8 input
+    }
+    0x26, 0x24, 4, RW, GPIO_IDBE(gpio_idbe) { /// GPIO Interrupt De-bounce Enable
+        gidbe0,  0,  0, u8; /// GPIO IRQ de-bounce enable for GPIO0
+        gidbe1,  1,  1, u8; /// GPIO IRQ de-bounce enable for GPIO1
+        gidbe2,  2,  2, u8; /// GPIO IRQ de-bounce enable for GPIO2
+        gidbe3,  3,  3, u8; /// GPIO IRQ de-bounce enable for GPIO3
+        gidbe4,  4,  4, u8; /// GPIO IRQ de-bounce enable for GPIO4
+        gidbe5,  5,  5, u8; /// GPIO IRQ de-bounce enable for GPIO5
+        gidbe6,  6,  6, u8; /// GPIO IRQ de-bounce enable for GPIO6
+        gidbe7,  7,  7, u8; /// GPIO IRQ de-bounce enable for GPIO7
+        gidbe8,  8,  8, u8; /// GPIO IRQ de-bounce enable for GPIO8
+    }
+    0x26, 0x28, 4, RW, GPIO_RAW(gpio_raw) { /// GPIO raw state
+        grawp0,  0,  0, u8; /// GPIO0 port raw state
+        grawp1,  1,  1, u8; /// GPIO1 port raw state
+        grawp2,  2,  2, u8; /// GPIO2 port raw state
+        grawp3,  3,  3, u8; /// GPIO3 port raw state
+        grawp4,  4,  4, u8; /// GPIO4 port raw state
+        grawp5,  5,  5, u8; /// GPIO5 port raw state
+        grawp6,  6,  6, u8; /// GPIO6 port raw state
+        grawp7,  7,  7, u8; /// GPIO7 port raw state
+        grawp8,  8,  8, u8; /// GPIO8 port raw state
+    }
     0x27, 0x08, 4, RW, DRX_TUNE2(drx_tune2) { /// Digital Tuning Register 2
         value, 0, 31, u32; /// DRX_TUNE2 tuning value
     }

--- a/dw1000/src/ll.rs
+++ b/dw1000/src/ll.rs
@@ -775,6 +775,19 @@ impl_register! {
         // maximum flexibility.
         value, 0, 31, u32; /// TX Power Control value
     }
+    0x1F, 0x00, 4, RW, CHAN_CTRL(chan_ctrl) { /// Channel Control Register
+        tx_chan, 0, 3, u8; /// Selects the transmit channel.
+        rx_chan, 4, 7, u8; /// Selects the receive channel.
+        dwsfd, 17, 17, u8; /// Enables the non-standard Decawave proprietary SFD sequence.
+        rxprf, 18, 19, u8; /// Selects the PRF used in the receiver.
+        tnssfd, 20, 20, u8; /// This bit enables the use of a user specified (non-standard) SFDin the transmitter.
+        rnssfd, 21, 21, u8; /// This bit enables the use of a user specified (non-standard) SFDin the receiver.
+        tx_pcode, 22, 26, u8; /// This field selects the preamble code used in the transmitter.
+        rx_pcode, 27, 31, u8; /// This field selects the preamble code used in the receiver.
+    }
+    0x21, 0x00, 1, RW, SFD_LENGTH(sfd_length) { /// This is the length of the SFD sequence used when the data rate is 850kbps and higher.
+        value, 0, 7, u8; /// This is the length of the SFD sequence used when the data rate is 850kbps and higher.
+    }
     0x23, 0x04, 2, RW, AGC_TUNE1(agc_tune1) { /// AGC Tuning register 1
         value, 0, 15, u16; /// AGC Tuning register 1 value
     }
@@ -946,12 +959,16 @@ impl_register! {
     0x28, 0x0C, 3, RW, RF_TXCTRL(rf_txctrl) { /// Analog TX Control Register
         txmtune, 5,  8, u8; /// Transmit mixer tuning register
         txmq,    9, 11, u8; /// Transmit mixer Q-factor tuning register
+        value, 0, 23, u32; /// The entire register
     }
     0x28, 0x30, 5, RW, LDOTUNE(ldotune) { /// LDO voltage tuning parameter
         value, 0, 39, u64; /// Internal LDO voltage tuning parameter
     }
     0x2A, 0x0B, 1, RW, TC_PGDELAY(tc_pgdelay) { /// Pulse Generator Delay
         value, 0, 7, u8; /// Transmitter Calibration - Pulse Generator Delay
+    }
+    0x2B, 0x07, 4, RW, FS_PLLCFG(fs_pllcfg) { /// Frequency synth - PLL configuration
+        value, 0, 31, u32; /// /// Frequency synth - PLL configuration
     }
     0x2B, 0x0B, 1, RW, FS_PLLTUNE(fs_plltune) { /// Frequency synth - PLL Tuning
         value, 0, 7, u8; /// Frequency synthesiser - PLL Tuning

--- a/dw1000/src/ll.rs
+++ b/dw1000/src/ll.rs
@@ -994,7 +994,7 @@ impl_register! {
     0x36, 0x28, 4, RW, PMSC_LEDC(pmsc_ledc) { /// PMSC LED Control Register
         blink_tim, 0, 7, u8; /// Blink time count value
         blnken, 8, 8, u8; /// Blink Enable
-        blnknow, 16, 19, u8; // Manually triggers an LED blink. There is one trigger bit per LED IO
+        blnknow, 16, 19, u8; /// Manually triggers an LED blink. There is one trigger bit per LED IO
     }
 }
 

--- a/dw1000/src/ll.rs
+++ b/dw1000/src/ll.rs
@@ -916,8 +916,32 @@ impl_register! {
         grawp7,  7,  7, u8; /// GPIO7 port raw state
         grawp8,  8,  8, u8; /// GPIO8 port raw state
     }
+    0x27, 0x02, 2, RW, DRX_TUNE0B(drx_tune0b) { /// Digital Tuning Register 0b
+        value, 0, 15, u16; /// DRX_TUNE0B tuning value
+    }
+    0x27, 0x04, 2, RW, DRX_TUNE1A(drx_tune1a) { /// Digital Tuning Register 1a
+        value, 0, 15, u16; /// DRX_TUNE1A tuning value
+    }
+    0x27, 0x06, 2, RW, DRX_TUNE1B(drx_tune1b) { /// Digital Tuning Register 1b
+        value, 0, 15, u16; /// DRX_TUNE1B tuning value
+    }
     0x27, 0x08, 4, RW, DRX_TUNE2(drx_tune2) { /// Digital Tuning Register 2
         value, 0, 31, u32; /// DRX_TUNE2 tuning value
+    }
+    0x27, 0x20, 2, RW, DRX_SFDTOC(drx_sfdtoc) { /// SFD timeout
+        count, 0, 15, u16; /// SFD detection timeout count
+    }
+    0x27, 0x24, 2, RW, DRX_PRETOC(drx_pretoc) { /// Preamble detection timeou
+        count, 0, 15, u16; /// Preamble detection timeout count
+    }
+    0x27, 0x26, 2, RW, DRX_TUNE4H(drx_tune4h) { /// Digital Tuning Register 4h
+        value, 0, 15, u16; /// DRX_TUNE4H tuning value
+    }
+    0x27, 0x28, 2, RO, DRX_CAR_INT(dxr_car_int) { /// Carrier Recovery Integrator Register
+        value, 0, 15, u16; /// value
+    }
+    0x27, 0x2C, 2, RO, RXPACC_NOSAT(rxpacc_nosat) { /// Digital debug register. Unsaturated accumulated preamble symbols.
+        value, 0, 15, u16; /// value
     }
     0x28, 0x0C, 3, RW, RF_TXCTRL(rf_txctrl) { /// Analog TX Control Register
         txmtune, 5,  8, u8; /// Transmit mixer tuning register

--- a/dw1000/src/ll.rs
+++ b/dw1000/src/ll.rs
@@ -956,6 +956,9 @@ impl_register! {
     0x27, 0x2C, 2, RO, RXPACC_NOSAT(rxpacc_nosat) { /// Digital debug register. Unsaturated accumulated preamble symbols.
         value, 0, 15, u16; /// value
     }
+    0x28, 0x0B, 1, RW, RF_RXCTRLH(rf_rxctrlh) { /// Analog RX Control Register
+        value, 0, 7, u8; /// Analog RX Control Register
+    }
     0x28, 0x0C, 3, RW, RF_TXCTRL(rf_txctrl) { /// Analog TX Control Register
         txmtune, 5,  8, u8; /// Transmit mixer tuning register
         txmq,    9, 11, u8; /// Transmit mixer Q-factor tuning register

--- a/dw1000/src/ranging.rs
+++ b/dw1000/src/ranging.rs
@@ -53,18 +53,10 @@ use serde::{
 };
 use ssmarshal;
 
-use crate::{
-    hl,
-    mac,
-    time::{
-        Duration,
-        Instant,
-    },
-    DW1000,
-    Error,
-    Ready,
-    Sending,
-};
+use crate::{hl, mac, time::{
+    Duration,
+    Instant,
+}, DW1000, Error, Ready, Sending, TxConfig};
 
 
 /// The transmission delay
@@ -198,6 +190,7 @@ impl<T> TxMessage<T> where T: Message {
             &buf[..T::LEN],
             self.recipient,
             Some(self.tx_time),
+            TxConfig::default()
         )?;
 
         Ok(future)

--- a/dw1000/src/time.rs
+++ b/dw1000/src/time.rs
@@ -119,7 +119,7 @@ impl Add<Duration> for Instant {
 /// A duration between two instants in DW1000 system time
 ///
 /// Internally uses the same 40-bit timestamps that the DW1000 uses.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[repr(C)]
 pub struct Duration(u64);
 

--- a/dwm1001/examples/dw1000_delayed_tx.rs
+++ b/dwm1001/examples/dw1000_delayed_tx.rs
@@ -15,6 +15,7 @@ use dwm1001::{
     dw1000::{
         mac,
         time::Duration,
+        TxConfig,
     },
     DWM1001,
     print,
@@ -38,6 +39,7 @@ fn main() -> ! {
                 b"ping",
                 mac::Address::broadcast(&mac::AddressMode::Short),
                 Some(tx_time),
+                TxConfig::default(),
             )
             .expect("Failed to start receiver");
 

--- a/dwm1001/examples/dw1000_only_tx.rs
+++ b/dwm1001/examples/dw1000_only_tx.rs
@@ -12,7 +12,10 @@ use nb::block;
 
 use dwm1001::{
     debug,
-    dw1000::mac,
+    dw1000::{
+        mac,
+        TxConfig,
+    },
     DWM1001,
     print,
 };
@@ -31,6 +34,7 @@ fn main() -> ! {
                 b"ping",
                 mac::Address::broadcast(&mac::AddressMode::Short),
                 None,
+                TxConfig::default(),
             )
             .expect("Failed to start receiver");
 

--- a/dwm1001/examples/dw1000_rx_tx.rs
+++ b/dwm1001/examples/dw1000_rx_tx.rs
@@ -23,6 +23,7 @@ use dwm1001::{
     debug,
     dw1000::{
         RxConfig,
+        TxConfig,
         mac,
     },
     nrf52832_hal::Delay,
@@ -125,6 +126,7 @@ fn main() -> ! {
                         b"ping",
                         mac::Address::broadcast(&mac::AddressMode::Short),
                         None,
+                        TxConfig::default()
                     )
                     .expect("Failed to broadcast ping");
 


### PR DESCRIPTION
Very nice library!
But I missed some features, though.

This PR adds the ability to set the bitrate, PRF, preamble length, channel and SFD sequence.

It's done by expanding the existing RxConfig and adding a new TxConfig.
Just like with the RxConfig, the TxConfig is now given as a parameter to the Send function.
Of course all the registers have been defined in the ll.rs.
The configs and the enums they now use live in their own file to keep hl.rs a bit more clean.

There's also a new hl function (with registers) to enable the LEDs using the built-in gpio functionality.

This does break existing code as the send function now requires an extra parameter. Any code that initializes the RxConfig itself will also need to adapt to the new fields. If released, this should not be part of version 0.3, but of a 0.4.
I've taken care that all the defaults have the same values as it was before this PR.

The defaults now are:
- 6.8 Mbps
- 16 Mhz PRF
- 128 symbols preamble
- Channel 5
- IEEE SFD sequence

With this setup, more configuration options could be added. But that's something for later perhaps.
I have tested this with DWM1000 modules, but can't guarantee that every combination of hardware and configurations actually works.