### PR TITLE
Update dependencies

### DIFF
--- a/dw1000/Cargo.toml
+++ b/dw1000/Cargo.toml
@@ -18,8 +18,9 @@ travis-ci = { repository = "braun-embedded/rust-dw1000" }
 
 
 [dependencies]
+byte         = "0.2.4"
 embedded-hal = "0.2.4"
-ieee802154   = "0.3.0"
+ieee802154   = "0.5.0"
 nb           = "1.0.0"
 
 [dependencies.serde]

--- a/dw1000/Cargo.toml
+++ b/dw1000/Cargo.toml
@@ -24,7 +24,7 @@ ieee802154   = "0.5.0"
 nb           = "1.0.0"
 
 [dependencies.serde]
-version = "1.0.115"
+version = "1.0.124"
 default-features = false
 features = ["derive"]
 

--- a/dw1000/src/ranging.rs
+++ b/dw1000/src/ranging.rs
@@ -132,7 +132,7 @@ pub struct RxMessage<T: Message> {
     pub rx_time: Instant,
 
     /// The source of the message
-    pub source: mac::Address,
+    pub source: Option<mac::Address>,
 
     /// The message data
     pub payload: T,
@@ -148,7 +148,7 @@ pub struct TxMessage<T: Message> {
     ///
     /// This is an IEEE 802.15.4 MAC address. This could be a broadcast address,
     /// for messages that are sent to all other nodes in range.
-    pub recipient: mac::Address,
+    pub recipient: Option<mac::Address>,
 
     /// The time this message is going to be sent
     ///

--- a/dwm1001/Cargo.toml
+++ b/dwm1001/Cargo.toml
@@ -22,7 +22,7 @@ travis-ci = { repository = "braun-embedded/rust-dw1000" }
 
 
 [dependencies]
-cortex-m-rt             = { version = "0.6.12", optional = true }
+cortex-m-rt             = { version = "0.6.13", optional = true }
 cortex-m-semihosting    = "0.3.5"
 embedded-hal            = "0.2.4"
 embedded-timeout-macros = "0.3.0"

--- a/dwm1001/Cargo.toml
+++ b/dwm1001/Cargo.toml
@@ -22,11 +22,14 @@ travis-ci = { repository = "braun-embedded/rust-dw1000" }
 
 
 [dependencies]
-cortex-m-rt             = { version = "0.6.13", optional = true }
 cortex-m-semihosting    = "0.3.5"
 embedded-hal            = "0.2.4"
 embedded-timeout-macros = "0.3.0"
 lis2dh12                = "0.6.0"
+
+[dependencies.cortex-m-rt]
+version  = "0.6.13"
+optional = true
 
 [dependencies.dw1000]
 version = "0.5.0"

--- a/dwm1001/Cargo.toml
+++ b/dwm1001/Cargo.toml
@@ -22,6 +22,7 @@ travis-ci = { repository = "braun-embedded/rust-dw1000" }
 
 
 [dependencies]
+cortex-m                = "0.7.2"
 cortex-m-semihosting    = "0.3.5"
 embedded-hal            = "0.2.4"
 embedded-timeout-macros = "0.3.0"
@@ -35,10 +36,6 @@ optional = true
 version = "0.5.0"
 path    = "../dw1000"
 
-[dependencies.cortex-m]
-version  = ">= 0.5.10, < 0.7"
-features = [ "const-fn" ]
-
 [dependencies.nrf52832-hal]
 version          = "0.12.0"
 default-features = false
@@ -46,7 +43,7 @@ features         = [ "xxAA-package" ]
 
 
 [dev-dependencies]
-heapless          = "0.5.5"
+heapless          = "0.6.1"
 nb                = "1.0.0"
 panic-semihosting = "0.5.3"
 

--- a/dwm1001/examples/dw1000_ranging_tag.rs
+++ b/dwm1001/examples/dw1000_ranging_tag.rs
@@ -165,7 +165,7 @@ fn main() -> ! {
             // If this is not a PAN ID and short address, it doesn't
             // come from a compatible node. Ignore it.
             let (pan_id, addr) = match response.source {
-                mac::Address::Short(pan_id, addr) =>
+                Some(mac::Address::Short(pan_id, addr)) =>
                     (pan_id, addr),
                 _ =>
                     continue,

--- a/dwm1001/examples/dw1000_rx_tx.rs
+++ b/dwm1001/examples/dw1000_rx_tx.rs
@@ -108,7 +108,7 @@ fn main() -> ! {
                 // messages from other kinds of nodes, so let's just assume this
                 // is going to be a PAN ID and short address.
                 let source = match message.frame.header.source {
-                    mac::Address::Short(pan_id, address) =>
+                    Some(mac::Address::Short(pan_id, address)) =>
                         [pan_id.0, address.0],
                     _ =>
                         continue,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,8 +2,7 @@
 
 (
     cd dw1000 &&
-    ./scripts/build.sh)
-
+    ./scripts/build.sh) &&
 (
     cd dwm1001 &&
     ./scripts/build.sh)


### PR DESCRIPTION
I tried and failed to upgrade to the latest version of the `ieee802154` crate. The commit that does the upgrade introduces the following error when trying to build one of the `dwm1001` examples:
```
$ cargo build --example blink --features=dev,rt
   Compiling dwm1001 v0.4.0 (/home/hanno/Projects/braun-embedded/dw1000/dwm1001)
error: no global memory allocator found but one is required; link to std or add `#[global_allocator]` to a static item that implements the GlobalAlloc trait.

error: `#[alloc_error_handler]` function required, but not found

error: aborting due to 2 previous errors

error: could not compile `dwm1001`

To learn more, run the command again with --verbose.
```

My understanding is that this is caused by *something* in the dependency tree depending on `alloc`, either directly or through `std`. I wasn't able to figure out where that could happen, and if that's even the reason for this error. I can't spend any more time on this right now, so I'm stopping here.

I'm opening this as a draft, to document that I tried to do the update, and in case anyone has any insights or wants to pick this up.