### PR TITLE
Fix linker errors when building examples

### DIFF
--- a/dwm1001/Cargo.toml
+++ b/dwm1001/Cargo.toml
@@ -29,7 +29,7 @@ embedded-timeout-macros = "0.3.0"
 lis2dh12                = "0.6.0"
 
 [dependencies.cortex-m-rt]
-version  = "0.7.0"
+version  = ">=0.6, <0.8"
 optional = true
 
 [dependencies.dw1000]


### PR DESCRIPTION
References to the interrupt handlers weren't found, because two
different `cortex-m-rt` versions were used. The `device.x` from the PAC
was probably no used, causing the errors.

This wasn't caught by CI (or running the build script locally), because
it worked, if `RUSTFLAGS` was set, even to an empty value. I don't know
why that is.