### PR TITLE
Rustfmt both crates and cargo.tomls

### DIFF
--- a/dw1000/Cargo.toml
+++ b/dw1000/Cargo.toml
@@ -1,16 +1,22 @@
 [package]
-name    = "dw1000"
+name = "dw1000"
 version = "0.5.0"
 authors = ["Hanno Braun <hanno@braun-embedded.com>"]
 edition = "2018"
 
-description   = "Driver for the Decawave DW1000 UWB wireless transceiver chip, providing radio communication based on IEEE 802.15.4 and distance measurement"
+description = "Driver for the Decawave DW1000 UWB wireless transceiver chip, providing radio communication based on IEEE 802.15.4 and distance measurement"
 documentation = "https://docs.rs/dw1000"
-repository    = "https://github.com/braun-embedded/rust-dw1000"
-license       = "0BSD"
-readme        = "README.md"
-categories    = ["embedded", "hardware-support", "no-std"]
-keywords      = ["decawave", "dw1000", "radio", "embedded-hal", "embedded-hal-driver"]
+repository = "https://github.com/braun-embedded/rust-dw1000"
+license = "0BSD"
+readme = "README.md"
+categories = ["embedded", "hardware-support", "no-std"]
+keywords = [
+    "decawave",
+    "dw1000",
+    "radio",
+    "embedded-hal",
+    "embedded-hal-driver",
+]
 
 
 [badges]
@@ -18,12 +24,12 @@ travis-ci = { repository = "braun-embedded/rust-dw1000" }
 
 
 [dependencies]
-byte         = "0.2.4"
+byte = "0.2.4"
 embedded-hal = "0.2.4"
-ieee802154   = "0.5.0"
-nb           = "1.0.0"
-fixed        = "1.7.0"
-micromath    = "2.0.0"
+ieee802154 = "0.5.0"
+nb = "1.0.0"
+fixed = "1.7.0"
+micromath = "2.0.0"
 
 
 [dependencies.serde]

--- a/dwm1001/Cargo.toml
+++ b/dwm1001/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name    = "dwm1001"
+name = "dwm1001"
 version = "0.5.0"
 authors = ["Hanno Braun <hanno@braun-embedded.com>"]
 edition = "2018"
 
-description   = "Board Support Crate for the Decawave DWM1001 module and development board"
+description = "Board Support Crate for the Decawave DWM1001 module and development board"
 documentation = "https://docs.rs/dwm1001"
-repository    = "https://github.com/braun-embedded/rust-dw1000"
-license       = "0BSD"
-readme        = "README.md"
-categories    = ["embedded", "hardware-support", "no-std"]
-keywords      = ["decawave", "dw1000", "bsc", "radio", "uwb"]
+repository = "https://github.com/braun-embedded/rust-dw1000"
+license = "0BSD"
+readme = "README.md"
+categories = ["embedded", "hardware-support", "no-std"]
+keywords = ["decawave", "dw1000", "bsc", "radio", "uwb"]
 
 
 [package.metadata.docs.rs]
@@ -22,29 +22,29 @@ travis-ci = { repository = "braun-embedded/rust-dw1000" }
 
 
 [dependencies]
-cortex-m                = "0.7.2"
-cortex-m-semihosting    = "0.3.5"
-embedded-hal            = "0.2.4"
+cortex-m = "0.7.2"
+cortex-m-semihosting = "0.3.5"
+embedded-hal = "0.2.4"
 embedded-timeout-macros = "0.3.0"
-lis2dh12                = "0.6.0"
+lis2dh12 = "0.6.0"
 
 [dependencies.cortex-m-rt]
-version  = ">=0.6, <0.8"
+version = ">=0.6, <0.8"
 optional = true
 
 [dependencies.dw1000]
 version = "0.5.0"
-path    = "../dw1000"
+path = "../dw1000"
 
 [dependencies.nrf52832-hal]
-version          = "0.14.0"
+version = "0.14.0"
 default-features = false
-features         = [ "xxAA-package" ]
+features = ["xxAA-package"]
 
 
 [dev-dependencies]
-heapless          = "0.7.0"
-nb                = "1.0.0"
+heapless = "0.7.0"
+nb = "1.0.0"
 panic-semihosting = "0.5.3"
 
 
@@ -58,73 +58,73 @@ semihosting = []
 
 
 [[example]]
-name              = "blink"
+name = "blink"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "uarte"
+name = "uarte"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "dw1000_delayed_tx"
+name = "dw1000_delayed_tx"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "dw1000_id"
+name = "dw1000_id"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "dw1000_only_rx"
+name = "dw1000_only_rx"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "dw1000_only_tx"
+name = "dw1000_only_tx"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "dw1000_ranging_anchor"
+name = "dw1000_ranging_anchor"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "dw1000_ranging_tag"
+name = "dw1000_ranging_tag"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "dw1000_reg_modify"
+name = "dw1000_reg_modify"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "dw1000_reg_rw"
+name = "dw1000_reg_rw"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "dw1000_reg_short"
+name = "dw1000_reg_short"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "dw1000_rx_tx"
+name = "dw1000_rx_tx"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "dw1000_subreg"
+name = "dw1000_subreg"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "dw1000_subreg_ext_addr"
+name = "dw1000_subreg_ext_addr"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "lis2dh12"
+name = "lis2dh12"
 required-features = ["dev", "rt"]
 
 [[example]]
-name              = "uarte_heapless_string"
+name = "uarte_heapless_string"
 required-features = ["dev", "rt"]
 
 
 [profile.release]
-incremental   = false
+incremental = false
 codegen-units = 1
-lto           = true
-opt-level     = 3
-debug         = true
+lto = true
+opt-level = 3
+debug = true

--- a/dwm1001/examples/blink.rs
+++ b/dwm1001/examples/blink.rs
@@ -1,9 +1,7 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 use dwm1001;
@@ -12,14 +10,10 @@ use nb::block;
 use dwm1001::{
     nrf52832_hal::{
         prelude::*,
-        timer::{
-            self,
-            Timer,
-        },
+        timer::{self, Timer},
     },
     DWM1001,
 };
-
 
 #[entry]
 fn main() -> ! {
@@ -35,8 +29,10 @@ fn main() -> ! {
     }
 }
 
-
-fn delay<T>(timer: &mut Timer<T>, cycles: u32) where T: timer::Instance {
+fn delay<T>(timer: &mut Timer<T>, cycles: u32)
+where
+    T: timer::Instance,
+{
     timer.start(cycles);
     block!(timer.wait()).unwrap();
 }

--- a/dwm1001/examples/dw1000_delayed_tx.rs
+++ b/dwm1001/examples/dw1000_delayed_tx.rs
@@ -3,38 +3,28 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 use nb::block;
 
 use dwm1001::{
     debug,
-    dw1000::{
-        hl::SendTime,
-        mac,
-        time::Duration,
-        TxConfig,
-    },
+    dw1000::{hl::SendTime, mac, time::Duration, TxConfig},
     nrf52832_hal::Delay,
-    DWM1001,
-    print,
+    print, DWM1001,
 };
-
 
 #[entry]
 fn main() -> ! {
     debug::init();
 
-    let     dwm1001 = DWM1001::take().unwrap();
-    let mut delay   = Delay::new(dwm1001.SYST);
-    let mut dw1000  = dwm1001.DW1000.init(&mut delay).unwrap();
+    let dwm1001 = DWM1001::take().unwrap();
+    let mut delay = Delay::new(dwm1001.SYST);
+    let mut dw1000 = dwm1001.DW1000.init(&mut delay).unwrap();
 
     loop {
-        let sys_time = dw1000.sys_time()
-            .expect("Failed to read system time");
+        let sys_time = dw1000.sys_time().expect("Failed to read system time");
         let tx_time = sys_time + Duration::from_nanos(10_000_000);
 
         let mut sending = dw1000
@@ -48,11 +38,9 @@ fn main() -> ! {
 
         print!("Sending... ");
 
-        block!(sending.wait())
-            .expect("Failed to send data");
+        block!(sending.wait()).expect("Failed to send data");
 
-        dw1000 = sending.finish_sending()
-            .expect("Failed to finish sending");
+        dw1000 = sending.finish_sending().expect("Failed to finish sending");
 
         print!("done\n");
     }

--- a/dwm1001/examples/dw1000_id.rs
+++ b/dwm1001/examples/dw1000_id.rs
@@ -3,22 +3,14 @@
 //! This example establishes SPI communication with the DW1000, reads its DEV_ID
 //! register, and verifies that all its fields are as expected.
 
-
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 
-use dwm1001::{
-    debug,
-    DWM1001,
-    print,
-};
-
+use dwm1001::{debug, print, DWM1001};
 
 #[entry]
 fn main() -> ! {
@@ -26,16 +18,17 @@ fn main() -> ! {
 
     let mut dwm1001 = DWM1001::take().unwrap();
 
-    let dev_id = dwm1001.DW1000
+    let dev_id = dwm1001
+        .DW1000
         .ll()
         .dev_id()
         .read()
         .expect("Failed to read DEV_ID register");
 
     assert_eq!(dev_id.ridtag(), 0xDECA);
-    assert_eq!(dev_id.model(),  0x01);
-    assert_eq!(dev_id.ver(),    0x3);
-    assert_eq!(dev_id.rev(),    0x0);
+    assert_eq!(dev_id.model(), 0x01);
+    assert_eq!(dev_id.ver(), 0x3);
+    assert_eq!(dev_id.rev(), 0x0);
 
     print!("Success!\n");
 

--- a/dwm1001/examples/dw1000_only_rx.rs
+++ b/dwm1001/examples/dw1000_only_rx.rs
@@ -3,41 +3,32 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 
 use dwm1001::{
-    block_timeout,
-    debug,
+    block_timeout, debug,
     dw1000::{
+        ranging::{self, Message as _},
         RxConfig,
-        ranging::{
-            self,
-            Message as _,
-        },
     },
-    DWM1001,
-    nrf52832_hal::{
-        Delay,
-        Timer,
-    },
+    nrf52832_hal::{Delay, Timer},
     prelude::*,
-    print,
+    print, DWM1001,
 };
-
 
 #[entry]
 fn main() -> ! {
     debug::init();
 
     let mut dwm1001 = DWM1001::take().unwrap();
-    let mut delay  = Delay::new(dwm1001.SYST);
+    let mut delay = Delay::new(dwm1001.SYST);
 
     dwm1001.DW_RST.reset_dw1000(&mut delay);
-    let mut dw1000 = dwm1001.DW1000.init(&mut delay)
+    let mut dw1000 = dwm1001
+        .DW1000
+        .init(&mut delay)
         .expect("Failed to initialize DW1000");
 
     // Configure timer
@@ -47,7 +38,7 @@ fn main() -> ! {
         let mut receiving = dw1000
             .receive(RxConfig {
                 frame_filtering: false,
-                .. RxConfig::default()
+                ..RxConfig::default()
             })
             .expect("Failed to start receiver");
 
@@ -58,13 +49,12 @@ fn main() -> ! {
 
         let result = block_timeout!(&mut timer, receiving.wait(&mut buffer));
 
-        dw1000 = receiving.finish_receiving()
+        dw1000 = receiving
+            .finish_receiving()
             .expect("Failed to finish receiving");
 
         let message = match result {
-            Ok(message) => {
-                message
-            }
+            Ok(message) => message,
             Err(error) => {
                 print!("Error: {:?}\n", error);
                 continue;
@@ -77,13 +67,21 @@ fn main() -> ! {
             dwm1001.leds.D10.disable();
             continue;
         }
-        if message.frame.payload.starts_with(ranging::Request::PRELUDE.0) {
+        if message
+            .frame
+            .payload
+            .starts_with(ranging::Request::PRELUDE.0)
+        {
             dwm1001.leds.D11.enable();
             delay.delay_ms(10u32);
             dwm1001.leds.D11.disable();
             continue;
         }
-        if message.frame.payload.starts_with(ranging::Response::PRELUDE.0) {
+        if message
+            .frame
+            .payload
+            .starts_with(ranging::Response::PRELUDE.0)
+        {
             dwm1001.leds.D12.enable();
             delay.delay_ms(10u32);
             dwm1001.leds.D12.disable();

--- a/dwm1001/examples/dw1000_only_tx.rs
+++ b/dwm1001/examples/dw1000_only_tx.rs
@@ -3,33 +3,25 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 use nb::block;
 
 use dwm1001::{
     debug,
-    dw1000::{
-        hl::SendTime,
-        mac,
-        TxConfig,
-    },
+    dw1000::{hl::SendTime, mac, TxConfig},
     nrf52832_hal::Delay,
-    DWM1001,
-    print,
+    print, DWM1001,
 };
-
 
 #[entry]
 fn main() -> ! {
     debug::init();
 
-    let     dwm1001 = DWM1001::take().unwrap();
-    let mut delay   = Delay::new(dwm1001.SYST);
-    let mut dw1000  = dwm1001.DW1000.init(&mut delay).unwrap();
+    let dwm1001 = DWM1001::take().unwrap();
+    let mut delay = Delay::new(dwm1001.SYST);
+    let mut dw1000 = dwm1001.DW1000.init(&mut delay).unwrap();
 
     loop {
         let mut sending = dw1000
@@ -41,11 +33,9 @@ fn main() -> ! {
             )
             .expect("Failed to start receiver");
 
-        block!(sending.wait())
-            .expect("Failed to send data");
+        block!(sending.wait()).expect("Failed to send data");
 
-        dw1000 = sending.finish_sending()
-            .expect("Failed to finish sending");
+        dw1000 = sending.finish_sending().expect("Failed to finish sending");
 
         print!(".");
     }

--- a/dwm1001/examples/dw1000_ranging_tag.rs
+++ b/dwm1001/examples/dw1000_ranging_tag.rs
@@ -10,40 +10,26 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 
 use dwm1001::{
-    prelude::*,
-    debug,
+    block_timeout, debug,
     dw1000::{
-        RxConfig,
         mac,
-        ranging::{
-            self,
-            Message as _RangingMessage,
-        },
+        ranging::{self, Message as _RangingMessage},
+        RxConfig,
     },
     nrf52832_hal::{
-        gpio::{
-            p0::P0_17,
-            Output,
-            PushPull,
-        },
+        gpio::{p0::P0_17, Output, PushPull},
         pac::SPIM2,
         rng::Rng,
-        Delay,
-        Spim,
-        Timer,
+        Delay, Spim, Timer,
     },
-    DWM1001,
-    block_timeout,
-    print,
+    prelude::*,
+    print, DWM1001,
 };
-
 
 #[entry]
 fn main() -> ! {
@@ -51,16 +37,20 @@ fn main() -> ! {
 
     let mut dwm1001 = DWM1001::take().unwrap();
 
-    let mut delay  = Delay::new(dwm1001.SYST);
-    let mut rng    = Rng::new(dwm1001.RNG);
+    let mut delay = Delay::new(dwm1001.SYST);
+    let mut rng = Rng::new(dwm1001.RNG);
 
     dwm1001.DW_RST.reset_dw1000(&mut delay);
-    let mut dw1000 = dwm1001.DW1000.init(&mut delay)
+    let mut dw1000 = dwm1001
+        .DW1000
+        .init(&mut delay)
         .expect("Failed to initialize DW1000");
 
-    dw1000.enable_tx_interrupts()
+    dw1000
+        .enable_tx_interrupts()
         .expect("Failed to enable TX interrupts");
-    dw1000.enable_rx_interrupts()
+    dw1000
+        .enable_rx_interrupts()
         .expect("Failed to enable RX interrupts");
 
     let mut dw_irq = dwm1001.DW_IRQ;
@@ -72,7 +62,8 @@ fn main() -> ! {
     // now.
     //
     // [1] https://github.com/Decawave/dwm1001-examples
-    dw1000.set_antenna_delay(16456, 16300)
+    dw1000
+        .set_antenna_delay(16456, 16300)
         .expect("Failed to set antenna delay");
 
     // Set network address
@@ -94,27 +85,21 @@ fn main() -> ! {
 
         timeout_timer.start(500_000u32);
         let message = block_timeout!(&mut timeout_timer, {
-            dw_irq.wait_for_interrupts(
-                &mut gpiote,
-                &mut timeout_timer,
-            );
+            dw_irq.wait_for_interrupts(&mut gpiote, &mut timeout_timer);
             receiving.wait(&mut buf)
         });
 
-        dw1000 = receiving.finish_receiving()
+        dw1000 = receiving
+            .finish_receiving()
             .expect("Failed to finish receiving");
 
         let message = match message {
             Ok(message) => message,
-            Err(_)      => continue, //ignore error
+            Err(_) => continue, //ignore error
         };
 
-        let ping =
-            ranging::Ping::decode::<
-                Spim<SPIM2>,
-                P0_17<Output<PushPull>>,
-            >(&message)
-                .expect("Failed to decode ping");
+        let ping = ranging::Ping::decode::<Spim<SPIM2>, P0_17<Output<PushPull>>>(&message)
+            .expect("Failed to decode ping");
         if let Some(ping) = ping {
             // Received ping from an anchor. Reply with a ranging
             // request.
@@ -134,26 +119,18 @@ fn main() -> ! {
 
             timeout_timer.start(500_000u32);
             block_timeout!(&mut timeout_timer, {
-                dw_irq.wait_for_interrupts(
-                    &mut gpiote,
-                    &mut timeout_timer,
-                );
+                dw_irq.wait_for_interrupts(&mut gpiote, &mut timeout_timer);
                 sending.wait()
             })
             .expect("Failed to send ranging request");
 
-            dw1000 = sending.finish_sending()
-                .expect("Failed to finish sending");
+            dw1000 = sending.finish_sending().expect("Failed to finish sending");
 
             continue;
         }
 
-        let response =
-            ranging::Response::decode::<
-                Spim<SPIM2>,
-                P0_17<Output<PushPull>>,
-            >(&message)
-                .expect("Failed to decode response");
+        let response = ranging::Response::decode::<Spim<SPIM2>, P0_17<Output<PushPull>>>(&message)
+            .expect("Failed to decode response");
         if let Some(response) = response {
             // Received ranging response from anchor. Now we can compute the
             // distance.
@@ -165,10 +142,8 @@ fn main() -> ! {
             // If this is not a PAN ID and short address, it doesn't
             // come from a compatible node. Ignore it.
             let (pan_id, addr) = match response.source {
-                Some(mac::Address::Short(pan_id, addr)) =>
-                    (pan_id, addr),
-                _ =>
-                    continue,
+                Some(mac::Address::Short(pan_id, addr)) => (pan_id, addr),
+                _ => continue,
             };
 
             // Ranging response received. Compute distance.
@@ -178,11 +153,7 @@ fn main() -> ! {
             delay.delay_ms(10u32);
             dwm1001.leds.D9.disable();
 
-            print!("{:04x}:{:04x} - {} mm\n",
-                pan_id.0,
-                addr.0,
-                distance_mm,
-            );
+            print!("{:04x}:{:04x} - {} mm\n", pan_id.0, addr.0, distance_mm,);
 
             continue;
         }

--- a/dwm1001/examples/dw1000_reg_modify.rs
+++ b/dwm1001/examples/dw1000_reg_modify.rs
@@ -3,18 +3,11 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 
-use dwm1001::{
-    debug,
-    DWM1001,
-    print,
-};
-
+use dwm1001::{debug, print, DWM1001};
 
 #[entry]
 fn main() -> ! {
@@ -25,24 +18,22 @@ fn main() -> ! {
     print!("Initializing...\n");
 
     // Initialize PANADR, so we can test `modify` in a controlled environment
-    dwm1001.DW1000
+    dwm1001
+        .DW1000
         .ll()
         .panadr()
-        .write(|w|
-            w
-                .short_addr(0x1234)
-                .pan_id(0xabcd)
-        )
+        .write(|w| w.short_addr(0x1234).pan_id(0xabcd))
         .expect("Failed to write to register");
 
     print!("Modifying...\n");
 
-    dwm1001.DW1000
+    dwm1001
+        .DW1000
         .ll()
         .panadr()
         .modify(|r, w| {
             assert_eq!(r.short_addr(), 0x1234);
-            assert_eq!(r.pan_id(),     0xabcd);
+            assert_eq!(r.pan_id(), 0xabcd);
 
             w.pan_id(0x5a5a)
         })
@@ -50,14 +41,15 @@ fn main() -> ! {
 
     print!("Reading...\n");
 
-    let panadr = dwm1001.DW1000
+    let panadr = dwm1001
+        .DW1000
         .ll()
         .panadr()
         .read()
         .expect("Failed to read from register");
 
     assert_eq!(panadr.short_addr(), 0x1234);
-    assert_eq!(panadr.pan_id(),     0x5a5a);
+    assert_eq!(panadr.pan_id(), 0x5a5a);
 
     print!("Success!\n");
 

--- a/dwm1001/examples/dw1000_reg_rw.rs
+++ b/dwm1001/examples/dw1000_reg_rw.rs
@@ -5,18 +5,11 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 
-use dwm1001::{
-    debug,
-    DWM1001,
-    print,
-};
-
+use dwm1001::{debug, print, DWM1001};
 
 #[entry]
 fn main() -> ! {
@@ -26,12 +19,12 @@ fn main() -> ! {
 
     print!("Writing...\n");
 
-    dwm1001.DW1000
+    dwm1001
+        .DW1000
         .ll()
         .tx_fctrl()
-        .write(|w|
-            w
-                .tflen(0b100_1001)
+        .write(|w| {
+            w.tflen(0b100_1001)
                 .tfle(0b10_1)
                 .txbr(0b10)
                 .tr(0b1)
@@ -40,25 +33,26 @@ fn main() -> ! {
                 .pe(0b10)
                 .txboffs(0b1101_0010_11)
                 .ifsdelay(0b0110_0110)
-        )
+        })
         .expect("Failed to write to register");
 
     print!("Reading...\n");
 
-    let tx_fctrl = dwm1001.DW1000
+    let tx_fctrl = dwm1001
+        .DW1000
         .ll()
         .tx_fctrl()
         .read()
         .expect("Failed to read from register");
 
-    assert_eq!(tx_fctrl.tflen(),    0b1001001);
-    assert_eq!(tx_fctrl.tfle(),     0b101);
-    assert_eq!(tx_fctrl.txbr(),     0b10);
-    assert_eq!(tx_fctrl.tr(),       0b1);
-    assert_eq!(tx_fctrl.txprf(),    0b01);
-    assert_eq!(tx_fctrl.txpsr(),    0b01);
-    assert_eq!(tx_fctrl.pe(),       0b10);
-    assert_eq!(tx_fctrl.txboffs(),  0b1101001011);
+    assert_eq!(tx_fctrl.tflen(), 0b1001001);
+    assert_eq!(tx_fctrl.tfle(), 0b101);
+    assert_eq!(tx_fctrl.txbr(), 0b10);
+    assert_eq!(tx_fctrl.tr(), 0b1);
+    assert_eq!(tx_fctrl.txprf(), 0b01);
+    assert_eq!(tx_fctrl.txpsr(), 0b01);
+    assert_eq!(tx_fctrl.pe(), 0b10);
+    assert_eq!(tx_fctrl.txboffs(), 0b1101001011);
     assert_eq!(tx_fctrl.ifsdelay(), 0b01100110);
 
     print!("Success!\n");

--- a/dwm1001/examples/dw1000_reg_short.rs
+++ b/dwm1001/examples/dw1000_reg_short.rs
@@ -8,18 +8,11 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 
-use dwm1001::{
-    debug,
-    DWM1001,
-    print,
-};
-
+use dwm1001::{debug, print, DWM1001};
 
 #[entry]
 fn main() -> ! {
@@ -29,7 +22,8 @@ fn main() -> ! {
 
     print!("Writing...\n");
 
-    dwm1001.DW1000
+    dwm1001
+        .DW1000
         .ll()
         .dx_time()
         .write(|w| w.value(0x1122334455))
@@ -37,7 +31,8 @@ fn main() -> ! {
 
     print!("Reading...\n");
 
-    let dx_time = dwm1001.DW1000
+    let dx_time = dwm1001
+        .DW1000
         .ll()
         .dx_time()
         .read()

--- a/dwm1001/examples/dw1000_rx_tx.rs
+++ b/dwm1001/examples/dw1000_rx_tx.rs
@@ -11,33 +11,19 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 use dw1000::hl::SendTime;
 use heapless::FnvIndexSet;
 
 use dwm1001::{
+    block_timeout, debug,
+    dw1000::{mac, RxConfig, TxConfig},
+    nrf52832_hal::{rng::Rng, Delay, Timer},
     prelude::*,
-    debug,
-    dw1000::{
-        RxConfig,
-        TxConfig,
-        mac,
-    },
-    nrf52832_hal::{
-        Delay,
-        Timer,
-        rng::Rng,
-    },
-    DWM1001,
-    block_timeout,
-    repeat_timeout,
-    print,
+    print, repeat_timeout, DWM1001,
 };
-
 
 #[entry]
 fn main() -> ! {
@@ -47,11 +33,13 @@ fn main() -> ! {
 
     let mut dwm1001 = DWM1001::take().unwrap();
 
-    let mut delay  = Delay::new(dwm1001.SYST);
-    let mut rng    = Rng::new(dwm1001.RNG);
+    let mut delay = Delay::new(dwm1001.SYST);
+    let mut rng = Rng::new(dwm1001.RNG);
 
     dwm1001.DW_RST.reset_dw1000(&mut delay);
-    let mut dw1000 = dwm1001.DW1000.init(&mut delay)
+    let mut dw1000 = dwm1001
+        .DW1000
+        .init(&mut delay)
         .expect("Failed to initialize DW1000");
 
     // Set network address
@@ -63,9 +51,9 @@ fn main() -> ! {
         .expect("Failed to set address");
 
     // Configure timer
-    let mut task_timer    = Timer::new(dwm1001.TIMER0);
+    let mut task_timer = Timer::new(dwm1001.TIMER0);
     let mut timeout_timer = Timer::new(dwm1001.TIMER1);
-    let mut output_timer  = Timer::new(dwm1001.TIMER2);
+    let mut output_timer = Timer::new(dwm1001.TIMER2);
 
     let receive_time = 500_000 + (rng.random_u32() % 500_000);
 
@@ -150,9 +138,9 @@ fn main() -> ! {
         if output_timer.wait().is_ok() {
             print!("\n-- Known nodes:\n");
             for node in &known_nodes {
-                print!("PAN ID: 0x{:04x}, Short Address: 0x{:04x}\n",
-                    node[0],
-                    node[1],
+                print!(
+                    "PAN ID: 0x{:04x}, Short Address: 0x{:04x}\n",
+                    node[0], node[1],
                 );
             }
 

--- a/dwm1001/examples/dw1000_subreg.rs
+++ b/dwm1001/examples/dw1000_subreg.rs
@@ -3,18 +3,11 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 
-use dwm1001::{
-    debug,
-    DWM1001,
-    print,
-};
-
+use dwm1001::{debug, print, DWM1001};
 
 #[entry]
 fn main() -> ! {
@@ -24,18 +17,19 @@ fn main() -> ! {
 
     print!("Writing...\n");
 
-    dwm1001.DW1000
+    dwm1001
+        .DW1000
         .ll()
         .drx_tune2()
         .write(|w|
             // Careful, only specific values are allowed here.
-            w.value(0x311A002D)
-        )
+            w.value(0x311A002D))
         .expect("Failed to write to register");
 
     print!("Reading...\n");
 
-    let drx_tune2 = dwm1001.DW1000
+    let drx_tune2 = dwm1001
+        .DW1000
         .ll()
         .drx_tune2()
         .read()
@@ -45,18 +39,19 @@ fn main() -> ! {
 
     print!("Writing...\n");
 
-    dwm1001.DW1000
+    dwm1001
+        .DW1000
         .ll()
         .drx_tune2()
         .write(|w|
             // Careful, only specific values are allowed here.
-            w.value(0x313B006B)
-        )
+            w.value(0x313B006B))
         .expect("Failed to write to register");
 
     print!("Reading...\n");
 
-    let drx_tune2 = dwm1001.DW1000
+    let drx_tune2 = dwm1001
+        .DW1000
         .ll()
         .drx_tune2()
         .read()

--- a/dwm1001/examples/dw1000_subreg_ext_addr.rs
+++ b/dwm1001/examples/dw1000_subreg_ext_addr.rs
@@ -7,18 +7,11 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 
-use dwm1001::{
-    debug,
-    DWM1001,
-    print,
-};
-
+use dwm1001::{debug, print, DWM1001};
 
 #[entry]
 fn main() -> ! {
@@ -28,18 +21,19 @@ fn main() -> ! {
 
     print!("Writing...\n");
 
-    dwm1001.DW1000
+    dwm1001
+        .DW1000
         .ll()
         .lde_cfg2()
         .write(|w|
             // Careful, only specific values are allowed here.
-            w.value(0x1607)
-        )
+            w.value(0x1607))
         .expect("Failed to write to register");
 
     print!("Reading...\n");
 
-    let lde_cfg2 = dwm1001.DW1000
+    let lde_cfg2 = dwm1001
+        .DW1000
         .ll()
         .lde_cfg2()
         .read()
@@ -49,18 +43,19 @@ fn main() -> ! {
 
     print!("Writing...\n");
 
-    dwm1001.DW1000
+    dwm1001
+        .DW1000
         .ll()
         .lde_cfg2()
         .write(|w|
             // Careful, only specific values are allowed here.
-            w.value(0x0607)
-        )
+            w.value(0x0607))
         .expect("Failed to write to register");
 
     print!("Reading...\n");
 
-    let lde_cfg2 = dwm1001.DW1000
+    let lde_cfg2 = dwm1001
+        .DW1000
         .ll()
         .lde_cfg2()
         .read()

--- a/dwm1001/examples/uarte.rs
+++ b/dwm1001/examples/uarte.rs
@@ -1,9 +1,7 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use cortex_m_rt::entry;
 use nb::block;
@@ -11,14 +9,10 @@ use nb::block;
 use dwm1001::{
     nrf52832_hal::{
         prelude::*,
-        timer::{
-            self,
-            Timer,
-        },
+        timer::{self, Timer},
     },
     DWM1001,
 };
-
 
 #[entry]
 fn main() -> ! {
@@ -32,7 +26,7 @@ fn main() -> ! {
         0x6e, // N
         0x67, // G
         0x0d, // CR
-        0x0a  // LF
+        0x0a, // LF
     ];
 
     loop {
@@ -45,8 +39,10 @@ fn main() -> ! {
     }
 }
 
-
-fn delay<T>(timer: &mut Timer<T>, cycles: u32) where T: timer::Instance {
+fn delay<T>(timer: &mut Timer<T>, cycles: u32)
+where
+    T: timer::Instance,
+{
     timer.start(cycles);
     block!(timer.wait()).unwrap();
 }

--- a/dwm1001/examples/uarte_heapless_string.rs
+++ b/dwm1001/examples/uarte_heapless_string.rs
@@ -1,9 +1,7 @@
 #![no_main]
 #![no_std]
 
-
 extern crate panic_semihosting;
-
 
 use core::fmt::Write;
 
@@ -12,10 +10,12 @@ use heapless::String as HString;
 use nb::block;
 
 use dwm1001::{
-    nrf52832_hal::{prelude::*, timer::{self, Timer}},
+    nrf52832_hal::{
+        prelude::*,
+        timer::{self, Timer},
+    },
     DWM1001,
 };
-
 
 #[entry]
 fn main() -> ! {
@@ -24,8 +24,7 @@ fn main() -> ! {
     let mut timer = Timer::new(dwm1001.TIMER0);
 
     let mut s: HString<64> = HString::new();
-    s.push_str("halp plz ")
-        .expect("Failed to push to string");
+    s.push_str("halp plz ").expect("Failed to push to string");
     let original_len = s.len();
 
     for i in 0.. {
@@ -34,14 +33,13 @@ fn main() -> ! {
         dwm1001.leds.D12.disable();
         delay(&mut timer, 230_000); // 230ms
 
-        write!(s, "{}\r\n", i)
-            .expect("Failed to write to string");
+        write!(s, "{}\r\n", i).expect("Failed to write to string");
 
         dwm1001.uart.write(s.as_bytes()).unwrap();
 
         s.truncate(original_len);
     }
-    
+
     // convince the compiler this never terminates
     loop {}
 }

--- a/dwm1001/src/debug.rs
+++ b/dwm1001/src/debug.rs
@@ -12,20 +12,16 @@
 //! always compile it without the `semihosting` feature. Programs that enable
 //! semihosting cannot run without a debugger attached.
 
-
 use core::cell::RefCell;
 
 use cortex_m::interrupt::Mutex;
 use cortex_m_semihosting::hio::HStdout;
 
-
 /// Connects to the host's stdout
 ///
 /// Users can typically ignore this static, and use [`init`], [`print!`], and
 /// [`println!`] instead.
-pub static STDOUT: Mutex<RefCell<Option<HStdout>>> =
-    Mutex::new(RefCell::new(None));
-
+pub static STDOUT: Mutex<RefCell<Option<HStdout>>> = Mutex::new(RefCell::new(None));
 
 /// Initializes the debug output, if semihosting is enabled
 ///
@@ -43,14 +39,11 @@ pub fn init() {
         use cortex_m_semihosting::hio;
 
         interrupt::free(|cs| {
-            *STDOUT.borrow(cs).borrow_mut() = Some(
-                hio::hstdout()
-                    .expect("Failed to initialize semihosting")
-            );
+            *STDOUT.borrow(cs).borrow_mut() =
+                Some(hio::hstdout().expect("Failed to initialize semihosting"));
         });
     }
 }
-
 
 /// Sends a debug message to the host, if semihosting is enabled
 #[macro_export]

--- a/dwm1001/src/lib.rs
+++ b/dwm1001/src/lib.rs
@@ -13,11 +13,8 @@
 //! [nRF52832]: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52832
 //! [examples directory]: https://github.com/braun-robotics/rust-dwm1001/tree/master/examples
 
-
 #![no_std]
-
 #![deny(missing_docs)]
-
 
 pub use cortex_m;
 #[cfg(feature = "rt")]
@@ -27,10 +24,7 @@ pub use embedded_hal;
 
 pub use nrf52832_hal;
 
-pub use embedded_timeout_macros::{
-    block_timeout,
-    repeat_timeout,
-};
+pub use embedded_timeout_macros::{block_timeout, repeat_timeout};
 
 /// Exports traits that are usually needed when using this crate
 pub mod prelude {
@@ -39,68 +33,29 @@ pub mod prelude {
 
 pub mod debug;
 
-use cortex_m::{
-    asm,
-    interrupt,
-};
+use cortex_m::{asm, interrupt};
 use dw1000::DW1000;
 use embedded_hal::blocking::delay::DelayMs;
 use nrf52832_hal::{
     gpio::{
-        p0::{
-            self,
-            P0_16,
-            P0_17,
-            P0_18,
-            P0_20,
-            P0_28,
-            P0_29,
-        },
-        Disconnected,
-        Floating,
-        Input,
-        Level,
-        OpenDrainConfig,
-        Output,
-        PushPull,
+        p0::{self, P0_16, P0_17, P0_18, P0_20, P0_28, P0_29},
+        Disconnected, Floating, Input, Level, OpenDrainConfig, Output, PushPull,
     },
-    pac::{
-        self as nrf52,
-        CorePeripherals,
-        Interrupt,
-        Peripherals,
-        SPIM2,
-        TWIM1,
-    },
-    spim,
-    timer,
-    twim,
-    uarte::{
-        Parity as UartParity,
-        Baudrate as UartBaudrate,
-    },
-    Spim,
-    Timer,
-    Twim,
+    pac::{self as nrf52, CorePeripherals, Interrupt, Peripherals, SPIM2, TWIM1},
+    spim, timer, twim,
+    uarte::{Baudrate as UartBaudrate, Parity as UartParity},
+    Spim, Timer, Twim,
 };
 
 #[cfg(feature = "dev")]
 use nrf52832_hal::{
-    prelude::*,
     gpio::{
-        p0::{
-            P0_05,
-            P0_11,
-        },
+        p0::{P0_05, P0_11},
         Pin,
     },
-    pac::{
-        UARTE0,
-    },
-    uarte::{
-        self,
-        Uarte,
-    },
+    pac::UARTE0,
+    prelude::*,
+    uarte::{self, Uarte},
 };
 
 /// Optional Configuration struct for SPIM, not including pins
@@ -122,7 +77,7 @@ pub fn new_usb_uarte<TX, RX>(
     uart0: UARTE0,
     txd_pin: P0_05<TX>,
     rxd_pin: P0_11<RX>,
-    config: UsbUarteConfig
+    config: UsbUarteConfig,
 ) -> Uarte<nrf52::UARTE0> {
     Uarte::new(
         uart0,
@@ -133,7 +88,7 @@ pub fn new_usb_uarte<TX, RX>(
             rts: None,
         },
         config.parity,
-        config.baudrate
+        config.baudrate,
     )
 }
 
@@ -145,11 +100,7 @@ pub fn new_dw1000<SCK, MOSI, MISO, CS>(
     miso: P0_18<MISO>,
     cs: P0_17<CS>,
     spim_opts: Option<SpimConfig>,
-) -> DW1000<
-        Spim<nrf52::SPIM2>,
-        p0::P0_17<Output<PushPull>>,
-        dw1000::Uninitialized>
-{
+) -> DW1000<Spim<nrf52::SPIM2>, p0::P0_17<Output<PushPull>>, dw1000::Uninitialized> {
     let cfg = spim_opts.unwrap_or_else(|| SpimConfig {
         frequency: spim::Frequency::K500,
         mode: spim::MODE_0,
@@ -159,24 +110,20 @@ pub fn new_dw1000<SCK, MOSI, MISO, CS>(
     let spim = Spim::new(
         spim,
         spim::Pins {
-            sck : sck.into_push_pull_output(Level::Low).degrade(),
+            sck: sck.into_push_pull_output(Level::Low).degrade(),
             mosi: Some(mosi.into_push_pull_output(Level::Low).degrade()),
             miso: Some(miso.into_floating_input().degrade()),
         },
         cfg.frequency,
         cfg.mode,
-        cfg.orc
+        cfg.orc,
     );
 
     DW1000::new(spim, cs.into_push_pull_output(Level::High))
 }
 
 /// Create a new instance of the TWIM bus used for the accelerometer
-pub fn new_acc_twim<SCL, SDA>(
-    twim: TWIM1,
-    scl: P0_28<SCL>,
-    sda: P0_29<SDA>,
-) -> Twim<nrf52::TWIM1> {
+pub fn new_acc_twim<SCL, SDA>(twim: TWIM1, scl: P0_28<SCL>, sda: P0_29<SDA>) -> Twim<nrf52::TWIM1> {
     Twim::new(
         twim,
         twim::Pins {
@@ -186,7 +133,6 @@ pub fn new_acc_twim<SCL, SDA>(
         twim::Frequency::K250,
     )
 }
-
 
 /// Configuration parameters for the UART connected via the debugger
 pub struct UsbUarteConfig {
@@ -238,11 +184,7 @@ pub struct DWM1001 {
     pub DW_IRQ: DW_IRQ,
 
     /// The Decawave DW1000 Radio IC
-    pub DW1000: DW1000<
-        Spim<nrf52::SPIM2>,
-        p0::P0_17<Output<PushPull>>,
-        dw1000::Uninitialized
-    >,
+    pub DW1000: DW1000<Spim<nrf52::SPIM2>, p0::P0_17<Output<PushPull>>, dw1000::Uninitialized>,
 
     /// LIS2DH12 3-axis accelerometer
     ///
@@ -478,10 +420,7 @@ impl DWM1001 {
     /// This method will return an instance of `DWM1001` the first time it is
     /// called. It will return only `None` on subsequent calls.
     pub fn take() -> Option<Self> {
-        Some(Self::new(
-            CorePeripherals::take()?,
-            Peripherals::take()?,
-        ))
+        Some(Self::new(CorePeripherals::take()?, Peripherals::take()?))
     }
 
     /// Take ownership of a `DWM1001` instance, circumventing safety guarantees
@@ -497,10 +436,7 @@ impl DWM1001 {
     ///
     /// Always use `DWM1001::take`, unless you really know what you're doing.
     pub unsafe fn steal() -> Self {
-        Self::new(
-            CorePeripherals::steal(),
-            Peripherals::steal(),
-        )
+        Self::new(CorePeripherals::steal(), Peripherals::steal())
     }
 
     fn new(cp: CorePeripherals, p: Peripherals) -> Self {
@@ -517,12 +453,7 @@ impl DWM1001 {
         //   non-`dev` features may be used to manually configure the serial
         //   port.
         #[cfg(feature = "dev")]
-        let uarte0 = new_usb_uarte(
-            p.UARTE0,
-            pins.p0_05,
-            pins.p0_11,
-            UsbUarteConfig::default(),
-        );
+        let uarte0 = new_usb_uarte(p.UARTE0, pins.p0_05, pins.p0_11, UsbUarteConfig::default());
 
         DWM1001 {
             #[cfg(feature = "dev")]
@@ -530,15 +461,15 @@ impl DWM1001 {
 
             pins: Pins {
                 BT_WAKE_UP: pins.p0_02,
-                SPIS_CSn  : pins.p0_03,
-                SPIS_CLK  : pins.p0_04,
-                SPIS_MOSI : pins.p0_06,
-                SPIS_MISO : pins.p0_07,
-                RESETn    : pins.p0_21,
-                READY     : pins.p0_26,
+                SPIS_CSn: pins.p0_03,
+                SPIS_CLK: pins.p0_04,
+                SPIS_MOSI: pins.p0_06,
+                SPIS_MISO: pins.p0_07,
+                RESETn: pins.p0_21,
+                READY: pins.p0_26,
 
-                GPIO_8 : pins.p0_08,
-                GPIO_9 : pins.p0_09,
+                GPIO_8: pins.p0_08,
+                GPIO_9: pins.p0_09,
                 GPIO_10: pins.p0_10,
                 GPIO_12: pins.p0_12,
                 GPIO_13: pins.p0_13,
@@ -546,20 +477,26 @@ impl DWM1001 {
                 GPIO_23: pins.p0_23,
                 GPIO_27: pins.p0_27,
 
-                #[cfg(not(feature = "dev"))] UART_RX   : pins.p0_11,
-                #[cfg(not(feature = "dev"))] UART_TX   : pins.p0_05,
+                #[cfg(not(feature = "dev"))]
+                UART_RX: pins.p0_11,
+                #[cfg(not(feature = "dev"))]
+                UART_TX: pins.p0_05,
 
-                #[cfg(not(feature = "dev"))] GPIO_14: pins.p0_14,
-                #[cfg(not(feature = "dev"))] GPIO_22: pins.p0_22,
-                #[cfg(not(feature = "dev"))] GPIO_30: pins.p0_30,
-                #[cfg(not(feature = "dev"))] GPIO_31: pins.p0_31,
+                #[cfg(not(feature = "dev"))]
+                GPIO_14: pins.p0_14,
+                #[cfg(not(feature = "dev"))]
+                GPIO_22: pins.p0_22,
+                #[cfg(not(feature = "dev"))]
+                GPIO_30: pins.p0_30,
+                #[cfg(not(feature = "dev"))]
+                GPIO_31: pins.p0_31,
 
                 IRQ_ACC: pins.p0_25,
             },
 
             #[cfg(feature = "dev")]
             leds: Leds {
-                D9 : Led::new(pins.p0_30.degrade()),
+                D9: Led::new(pins.p0_30.degrade()),
                 D10: Led::new(pins.p0_31.degrade()),
                 D11: Led::new(pins.p0_22.degrade()),
                 D12: Led::new(pins.p0_14.degrade()),
@@ -568,91 +505,92 @@ impl DWM1001 {
             DW_RST: DW_RST::new(pins.p0_24),
             DW_IRQ: DW_IRQ::new(pins.p0_19),
 
-            DW1000: new_dw1000(p.SPIM2, pins.p0_16, pins.p0_20, pins.p0_18, pins.p0_17, None),
+            DW1000: new_dw1000(
+                p.SPIM2, pins.p0_16, pins.p0_20, pins.p0_18, pins.p0_17, None,
+            ),
 
             LIS2DH12: new_acc_twim(p.TWIM1, pins.p0_28, pins.p0_29),
 
             // nRF52 core peripherals
-            CBP  : cp.CBP,
+            CBP: cp.CBP,
             CPUID: cp.CPUID,
-            DCB  : cp.DCB,
-            DWT  : cp.DWT,
-            FPB  : cp.FPB,
-            FPU  : cp.FPU,
-            ITM  : cp.ITM,
-            MPU  : cp.MPU,
-            NVIC : cp.NVIC,
-            SCB  : cp.SCB,
-            SYST : cp.SYST,
-            TPIU : cp.TPIU,
+            DCB: cp.DCB,
+            DWT: cp.DWT,
+            FPB: cp.FPB,
+            FPU: cp.FPU,
+            ITM: cp.ITM,
+            MPU: cp.MPU,
+            NVIC: cp.NVIC,
+            SCB: cp.SCB,
+            SYST: cp.SYST,
+            TPIU: cp.TPIU,
 
             // nRF52 peripherals
-            FICR  : p.FICR,
-            UICR  : p.UICR,
-            BPROT : p.BPROT,
-            POWER : p.POWER,
-            CLOCK : p.CLOCK,
-            RADIO : p.RADIO,
+            FICR: p.FICR,
+            UICR: p.UICR,
+            BPROT: p.BPROT,
+            POWER: p.POWER,
+            CLOCK: p.CLOCK,
+            RADIO: p.RADIO,
 
             #[cfg(not(feature = "dev"))]
             UARTE0: p.UARTE0,
 
-            UART0 : p.UART0,
-            SPIM0 : p.SPIM0,
-            SPIS0 : p.SPIS0,
-            TWIM0 : p.TWIM0,
-            TWIS0 : p.TWIS0,
-            SPI0  : p.SPI0,
-            TWI0  : p.TWI0,
-            SPIM1 : p.SPIM1,
-            SPIS1 : p.SPIS1,
-            TWIS1 : p.TWIS1,
-            SPI1  : p.SPI1,
-            TWI1  : p.TWI1,
-            NFCT  : p.NFCT,
+            UART0: p.UART0,
+            SPIM0: p.SPIM0,
+            SPIS0: p.SPIS0,
+            TWIM0: p.TWIM0,
+            TWIS0: p.TWIS0,
+            SPI0: p.SPI0,
+            TWI0: p.TWI0,
+            SPIM1: p.SPIM1,
+            SPIS1: p.SPIS1,
+            TWIS1: p.TWIS1,
+            SPI1: p.SPI1,
+            TWI1: p.TWI1,
+            NFCT: p.NFCT,
             GPIOTE: p.GPIOTE,
-            SAADC : p.SAADC,
+            SAADC: p.SAADC,
             TIMER0: p.TIMER0,
             TIMER1: p.TIMER1,
             TIMER2: p.TIMER2,
-            RTC0  : p.RTC0,
-            TEMP  : p.TEMP,
-            RNG   : p.RNG,
-            ECB   : p.ECB,
-            CCM   : p.CCM,
-            AAR   : p.AAR,
-            WDT   : p.WDT,
-            RTC1  : p.RTC1,
-            QDEC  : p.QDEC,
-            COMP  : p.COMP,
+            RTC0: p.RTC0,
+            TEMP: p.TEMP,
+            RNG: p.RNG,
+            ECB: p.ECB,
+            CCM: p.CCM,
+            AAR: p.AAR,
+            WDT: p.WDT,
+            RTC1: p.RTC1,
+            QDEC: p.QDEC,
+            COMP: p.COMP,
             LPCOMP: p.LPCOMP,
-            SWI0  : p.SWI0,
-            EGU0  : p.EGU0,
-            SWI1  : p.SWI1,
-            EGU1  : p.EGU1,
-            SWI2  : p.SWI2,
-            EGU2  : p.EGU2,
-            SWI3  : p.SWI3,
-            EGU3  : p.EGU3,
-            SWI4  : p.SWI4,
-            EGU4  : p.EGU4,
-            SWI5  : p.SWI5,
-            EGU5  : p.EGU5,
+            SWI0: p.SWI0,
+            EGU0: p.EGU0,
+            SWI1: p.SWI1,
+            EGU1: p.EGU1,
+            SWI2: p.SWI2,
+            EGU2: p.EGU2,
+            SWI3: p.SWI3,
+            EGU3: p.EGU3,
+            SWI4: p.SWI4,
+            EGU4: p.EGU4,
+            SWI5: p.SWI5,
+            EGU5: p.EGU5,
             TIMER3: p.TIMER3,
             TIMER4: p.TIMER4,
-            PWM0  : p.PWM0,
-            PDM   : p.PDM,
-            NVMC  : p.NVMC,
-            PPI   : p.PPI,
-            MWU   : p.MWU,
-            PWM1  : p.PWM1,
-            PWM2  : p.PWM2,
-            RTC2  : p.RTC2,
-            I2S   : p.I2S,
+            PWM0: p.PWM0,
+            PDM: p.PDM,
+            NVMC: p.NVMC,
+            PPI: p.PPI,
+            MWU: p.MWU,
+            PWM1: p.PWM1,
+            PWM2: p.PWM2,
+            RTC2: p.RTC2,
+            I2S: p.I2S,
         }
     }
 }
-
 
 /// The nRF52 pins that are available on the DWM1001
 ///
@@ -750,13 +688,11 @@ pub struct Pins {
     // Pins before this comment are available outside the DWM1001. Pins after
     // this comment are connected to components on the board, and should
     // eventually be subsumed by higher-level abstractions.
-
     /// DWM1001: IRQ_ACC; nRF52: P0.25
     ///
     /// Connected to the accelerometer.
     pub IRQ_ACC: p0::P0_25<Disconnected>,
 }
-
 
 /// The LEDs on the DWM1001-Dev board
 ///
@@ -780,7 +716,6 @@ pub struct Leds {
     pub D12: Led,
 }
 
-
 /// An LED on the DWM1001-Dev board
 ///
 /// This struct is only available, if the `dev` feature is enabled.
@@ -802,17 +737,14 @@ impl Led {
 
     /// Enable the LED
     pub fn enable(&mut self) {
-        self.0.set_low()
-            .unwrap();
+        self.0.set_low().unwrap();
     }
 
     /// Disable the LED
     pub fn disable(&mut self) {
-        self.0.set_high()
-            .unwrap();
+        self.0.set_high().unwrap();
     }
 }
-
 
 /// The DW_RST pin (P0.24 on the nRF52)
 ///
@@ -833,20 +765,21 @@ impl DW_RST {
     /// [`DelayMs`] from the `embedded-hal` crate, which the user must supply.
     ///
     /// See [`nrf52832_hal::Delay`] for such an implementation.
-    pub fn reset_dw1000<D>(&mut self, delay: &mut D) where D: DelayMs<u32> {
+    pub fn reset_dw1000<D>(&mut self, delay: &mut D)
+    where
+        D: DelayMs<u32>,
+    {
         // This whole `Option` thing is a bit of a hack. What we actually need
         // here is the ability to put the pin into a tri-state mode that allows
         // us to switch input/output on the fly.
-        let dw_rst = self.0
+        let dw_rst = self
+            .0
             .take()
             .unwrap()
             // According the the DW1000 datasheet (section 5.6.3.1), the reset
             // pin should be pulled low using open-drain, and must never be
             // pulled high.
-            .into_open_drain_output(
-                OpenDrainConfig::Standard0Disconnect1,
-                Level::Low
-            );
+            .into_open_drain_output(OpenDrainConfig::Standard0Disconnect1, Level::Low);
 
         // Section 5.6.3.1 in the data sheet talks about keeping this low for
         // T-RST_OK, which would be 10-50 nanos. But table 15 makes it sound
@@ -861,7 +794,6 @@ impl DW_RST {
         delay.delay_ms(5);
     }
 }
-
 
 /// The DW_IRQ pin (P0.19 on the nRF52)
 ///
@@ -885,16 +817,12 @@ impl DW_IRQ {
     ///   DW1000.
     /// - This method disables interrupt handlers. No interrupt handler will be
     ///   called while this method is active.
-    pub fn wait_for_interrupts<T>(&mut self,
-        gpiote: &mut nrf52::GPIOTE,
-        timer:  &mut Timer<T>,
-    )
-        where T: timer::Instance
+    pub fn wait_for_interrupts<T>(&mut self, gpiote: &mut nrf52::GPIOTE, timer: &mut Timer<T>)
+    where
+        T: timer::Instance,
     {
         gpiote.config[0].write(|w| {
-            let w = w
-                .mode().event()
-                .polarity().lo_to_hi();
+            let w = w.mode().event().polarity().lo_to_hi();
 
             unsafe { w.psel().bits(19) }
         });
@@ -906,7 +834,9 @@ impl DW_IRQ {
 
             // Safe, as I don't believe this can interfere with the critical
             // section we're in.
-            unsafe { nrf52::NVIC::unmask(Interrupt::GPIOTE); }
+            unsafe {
+                nrf52::NVIC::unmask(Interrupt::GPIOTE);
+            }
             timer.enable_interrupt();
 
             asm::dsb();


### PR DESCRIPTION
While working on #145, I noticed lots of discrepancies from rustfmt's approach to formatting the crates.

This PR is *just* the crates after running `cargo fmt` with no actual code changes. Is there an alternative rustfmt config you'd like to use?